### PR TITLE
docs: add core and domain architecture guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 Guidance for AI coding agents and contributors working on this codebase. Follow these conventions so new work stays consistent with existing patterns.
 
+## Deep-dive docs
+
+Domain-specific guides (Portuguese prose, English filenames) live under **[`docs/`](./docs/README.md)** — **`core/`** (HTTP, shell, UI, SEO) vs **`domains/`** (bible, home, help) vs **`testing/`**. Start at [`docs/domains/bible/overview.md`](./docs/domains/bible/overview.md) for reader work, or [`docs/core/`](./docs/core/) for shared app infrastructure.
+
 ## Product context
 
 - **Bibleasy** (`bibleasy-frontend` in `package.json`) is a **Nuxt 4** web app for reading the Bible online.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ npm run preview
 
 ---
 
+## 📚 Documentação técnica
+
+Guias organizados em **`core/`** (base compartilhada), **`domains/`** (bible, home, help) e **`testing/`** — índice em **[`docs/README.md`](./docs/README.md)**.
+
+---
+
 ## 📁 Estrutura do Projeto
 
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,82 @@
+# Documentação técnica — Bibleasy Frontend
+
+Guias sobre **como cada parte do projeto funciona**, organizados em duas camadas:
+
+| Camada | Pasta | O que é |
+|--------|-------|---------|
+| **Core** | [`core/`](./core/) | Base compartilhada do app — HTTP, layout, UI, SEO, padrões de persistência. Vale para qualquer feature. |
+| **Domínios** | [`domains/`](./domains/) | Features de produto isoladas por rota/responsabilidade — espelham `app/pages/` e `app/components/`. |
+| **Testes** | [`testing/`](./testing/) | Vitest (unit / nuxt / e2e). |
+
+> Convenções gerais, stack e Docker: [`AGENTS.md`](../AGENTS.md) e [`README.md`](../README.md).
+
+## Core (`core/`)
+
+| Documento | O que cobre |
+|-----------|-------------|
+| [HTTP layer](./core/http-layer.md) | Plugin `$api`, `useApiFetch`, `useApi`, services |
+| [App shell](./core/app-shell.md) | Layout global, modais, SEO base, padrão de registro |
+| [Persistence patterns](./core/persistence-patterns.md) | Pinia, cookies, localStorage — **como** persistir (regras genéricas) |
+| [Routing overview](./core/routing-overview.md) | Mapa de rotas e responsabilidade de cada page |
+| [SEO](./core/seo.md) | `useSeoMeta`, schema.org, sitemap Nitro |
+| [Components and UI](./core/components-and-ui.md) | Pastas de componentes, ícones, temas, DaisyUI/PrimeVue |
+
+## Domínios (`domains/`)
+
+### Bible (`domains/bible/`)
+
+Leitura da Bíblia — maior domínio do app. Inclui bootstrap de catálogo (versões/livros) acoplado ao layout hoje.
+
+| Documento | O que cobre |
+|-----------|-------------|
+| [Overview](./domains/bible/overview.md) | Fronteiras do domínio, mapa de pastas, acoplamentos |
+| [URLs and references](./domains/bible/urls-and-references.md) | Formato de URL, parsing, navegação, hash `#vN` |
+| [Chapter reader](./domains/bible/chapter-reader.md) | Page `/bible/[reference]`, `BibleChapter`, SEO do capítulo |
+| [Verses and placeholders](./domains/bible/verses-and-placeholders.md) | Seleção, cópia, highlights, referências cruzadas |
+| [Search and selector](./domains/bible/search-and-selector.md) | `SearchModal`, seletor lateral, atalho de teclado |
+| [Catalog and metadata](./domains/bible/catalog-and-metadata.md) | `book.ts`, stores de versão, bootstrap de livros |
+| [Reading history](./domains/bible/reading-history.md) | Histórico local, último capítulo |
+
+### Home (`domains/home/`)
+
+| Documento | O que cobre |
+|-----------|-------------|
+| [Landing page](./domains/home/landing-page.md) | `/`, seções marketing, versículo do dia |
+
+### Help (`domains/help/`)
+
+| Documento | O que cobre |
+|-----------|-------------|
+| [Help center](./domains/help/help-center.md) | `/help`, FAQ, suporte, modal global |
+
+## Testes (`testing/`)
+
+| Documento | O que cobre |
+|-----------|-------------|
+| [Vitest projects](./testing/vitest.md) | unit / nuxt / e2e, espelhamento de `app/` |
+
+## Onde começar
+
+```mermaid
+flowchart TD
+  A[Nova implementação] --> B{É infra compartilhada?}
+  B -->|HTTP, layout, UI base| C[core/]
+  B -->|Não| D{Qual rota / feature?}
+  D -->|/bible| E[domains/bible/overview.md]
+  D -->|/| F[domains/home/]
+  D -->|/help| G[domains/help/]
+  D -->|Testes| H[testing/vitest.md]
+  E --> I[Doc específico do sub-tópico]
+```
+
+## Princípios transversais
+
+1. **Core vs domínio** — HTTP, layout e padrões de UI ficam em `core/`; regras de negócio da Bíblia ficam em `domains/bible/`.
+2. **SSR primeiro** — GETs declarativos via `useApiFetch` quando a page participa do render no servidor.
+3. **Tipos via Zod** — `app/types/<entidade>/`; inferir tipos, não duplicar interfaces.
+4. **pt-BR na UI** — strings visíveis e meta em português; comentários de código em inglês.
+5. **Espelhar o vizinho** — mesma pasta em `app/` que a feature que você está implementando.
+
+## Acoplamento atual (importante)
+
+O **layout global** carrega versões e livros da API antes de qualquer page — dados do domínio Bible, mas disponíveis em `/`, `/help` e `/bible`. Home usa `lastChapterUrl`; o header expõe busca bíblica. Detalhes e fronteiras: [Bible domain overview](./domains/bible/overview.md).

--- a/docs/core/app-shell.md
+++ b/docs/core/app-shell.md
@@ -1,0 +1,65 @@
+# App shell
+
+O **shell** é tudo que envolve o conteúdo de cada page sem ser regra de negócio de um domínio específico.
+
+Arquivo central: `app/layouts/default.vue`
+
+## Responsabilidades da plataforma
+
+| Responsabilidade | Onde |
+|------------------|------|
+| Estrutura visual (header + footer de slot) | Template do layout |
+| Meta global (og:image, canonical) | `useSeoMeta` / `useHead` no layout |
+| Modais registrados uma vez | Template + refs |
+| Atalhos globais (client) | `onMounted` no layout |
+
+## O que **não** deveria ser idealmente no shell
+
+Hoje o layout também **bootstrapa o catálogo bíblico** (versões + livros). Isso acopla o domínio Bible à plataforma — documentado em [Bible overview](../domains/bible/overview.md). Ao adicionar features não-bíblicas, evite expandir esse acoplamento.
+
+## Template
+
+```vue
+<div class="min-h-screen flex flex-col justify-between">
+  <LayoutHeader />
+  <slot />
+  <BibleSearchModal ref="searchModalRef" />
+  <HelpSupportModal ref="supportModalRef" />
+</div>
+```
+
+| Elemento | Domínio | Por que está no shell |
+|----------|---------|------------------------|
+| `LayoutHeader` | Core (`layout/header/`) | Chrome em todas as rotas |
+| `BibleSearchModal` | Bible | Atalho de teclado global — ver [Search and selector](../domains/bible/search-and-selector.md) |
+| `HelpSupportModal` | Help | Aberto do header via `useSupportModal` |
+
+## SEO global
+
+No layout:
+
+- `ogImage`, `twitterCard`, imagem fixa Bibleasy
+- `canonical` = origin + `route.fullPath`
+
+Meta **por page** (título, description, schema específico) ficam em cada `pages/*/index.vue`. Ver [SEO](./seo.md).
+
+## Padrão: modal global sem prop drilling
+
+Exemplo Help — replicável para outros modais cross-route:
+
+1. Modal no layout com `ref`.
+2. Composable `useSupportModal()` com `useState` guarda controller.
+3. `onMounted` → `supportModal.registerRef(supportModalRef)`.
+4. Qualquer componente chama `useSupportModal().open()`.
+
+Arquivos: `composables/useSupportModal.ts`, `components/help/support/SupportModal.vue`.
+
+## Falha cedo
+
+Sem versões/livros da API, o layout chama `createAppError` — a app inteira para. E2E e dev local precisam de backend ou mocks. Ver [HTTP layer](./http-layer.md).
+
+## Checklist: alterar o shell
+
+- [ ] Novo modal global? Mesmo padrão ref + composable de registro.
+- [ ] Novo fetch no layout? Questionar se é realmente cross-domain ou deveria ir a um domínio/layout aninhado.
+- [ ] Novo atalho de teclado? Guard para inputs e modificadores (ver Search no domínio Bible).

--- a/docs/core/components-and-ui.md
+++ b/docs/core/components-and-ui.md
@@ -1,0 +1,80 @@
+# Components and UI
+
+Convenções de UI **compartilhadas**. Componentes específicos de cada domínio estão em `app/components/<domínio>/`.
+
+## Organização de pastas
+
+```
+app/components/
+├── layout/header/   # Core — chrome global
+├── shared/          # Core — widgets reutilizáveis
+├── Icon.vue         # Core — ícones semânticos
+├── home/            # Domain Home
+├── help/            # Domain Help
+└── bible/           # Domain Bible
+```
+
+Regra: novo componente vai na pasta do **domínio** da feature. Só `layout/`, `shared/` e `Icon.vue` são core (shared infra).
+
+### Registro Nuxt
+
+`components/bible/chapter/index.vue` → `<BibleChapter>`. Prefira `index.vue` em subpastas coesas.
+
+## Bibliotecas
+
+| Necessidade | Escolha |
+|-------------|---------|
+| Botões, layout, temas | **DaisyUI** |
+| Dialogs/inputs complexos | **PrimeVue** (Aura global) |
+| Ícones | **`Icon`** — nunca `NuxtIcon` direto em features |
+| Animação | Tailwind + `<Transition>` |
+
+Config: `nuxt.config.ts`, estilos globais: `app/assets/css/main.css`.
+
+## Ícones
+
+`Icon.vue` — mapa `ICON_MAP`. Nova chave semântica aqui; não espalhar strings Iconify.
+
+## Temas
+
+- `@nuxtjs/color-mode`, cookie `theme`
+- UI: `ThemeSelectorPopover.vue` (header)
+- Utilities CSS: `h-header`, `top-header`, `h-screen-header` — usadas principalmente no leitor Bible
+
+## Header global
+
+`components/layout/header/index.vue` — logo, tema, help, user menu, links Bible (consome domínio Bible indiretamente).
+
+## Padrão de SFC
+
+```vue
+<script setup lang="ts">
+// types → props/emits → composables → computed/refs → handlers → lifecycle
+</script>
+```
+
+Comentários em inglês; strings visíveis em pt-BR.
+
+## Modais: global vs local
+
+| Modal | Pasta | Escopo |
+|-------|-------|--------|
+| `HelpSupportModal` | `help/support/` | Global — [Help](../domains/help/help-center.md) |
+| `BibleSearchModal` | `bible/` | Global no layout — [Bible search](../domains/bible/search-and-selector.md) |
+| `VersionModal`, `HistoryModal` | `bible/chapter/` | Local ao leitor |
+
+## Criar componente
+
+1. Identificar domínio pela rota/feature.
+2. Abrir vizinho na mesma pasta de `components/`.
+3. Lógica > ~15 linhas → composable (`composables/` ou `composables/bible/`).
+4. Props tipadas via types Zod inferidos.
+
+## Responsividade (referência Bible)
+
+O leitor define breakpoints `lg:` para painel lateral vs modal — ver [Chapter reader](../domains/bible/chapter-reader.md). Outros domínios seguem Tailwind padrão do arquivo mais próximo.
+
+## Assets
+
+- `public/` — estáticos
+- CSS entry único: `app/assets/css/main.css` (Tailwind v4)

--- a/docs/core/http-layer.md
+++ b/docs/core/http-layer.md
@@ -1,0 +1,97 @@
+# HTTP layer
+
+Infraestrutura HTTP compartilhada por **todos os domínios**. O frontend consome o REST API do [bibleasy-backend](https://github.com/viniciusrvcruz/bibleasy-backend).
+
+## Arquitetura
+
+```mermaid
+flowchart TB
+  subgraph domains [Domain pages / components]
+    P1[pages/*]
+    C1[components/*]
+  end
+
+  subgraph services [composables/services/]
+    S1[useVersionService]
+    S2[useBookService]
+    S3[useChapterService]
+    S4[useSupportService]
+  end
+
+  subgraph http [Core HTTP]
+    UAF[useApiFetch]
+    UA[useApi]
+    API[plugin api.ts]
+  end
+
+  domains --> services
+  services --> UAF & UA
+  UAF & UA --> API
+  API --> BE[(Backend /api/)]
+```
+
+Services vivem em `composables/services/` — **não** dentro de `composables/bible/`. Domínios consomem services; services não conhecem UI.
+
+## Plugin `$api`
+
+Arquivo: `app/plugins/api.ts`
+
+| Aspecto | Servidor (SSR) | Cliente |
+|---------|----------------|---------|
+| Base URL | `runtimeConfig.apiBaseUrl` | `runtimeConfig.public.apiBaseUrl` |
+| Prefixo | `{baseURL}/api/` | idem |
+| `X-Api-Key` | Sim | **Não** |
+| Content-Type | JSON (exceto `FormData`) | idem |
+
+Nunca exponha `NUXT_API_KEY` no client.
+
+## `useApiFetch` — GETs com SSR
+
+Arquivo: `app/composables/useApiFetch.ts`
+
+```ts
+useFetch(url, { key: url, $fetch: useNuxtApp().$api, ...options })
+```
+
+Use em pages/services quando o dado deve ser buscado no servidor e deduplicado por URL.
+
+## `useApi` — chamadas imperativas
+
+Arquivo: `app/composables/useApi.ts` — `get`, `post`, `put`, `del`.
+
+Use para mutações, lazy load ou pós-interação (ex.: troca de versão, submit de formulário).
+
+## Services por domínio
+
+| Service | Domínio | Endpoint |
+|---------|---------|----------|
+| `useVersionService` | Bible (catálogo) | `GET versions` |
+| `useBookService` | Bible (catálogo) | `GET versions/{id}/books` |
+| `useChapterService` | Bible (leitor) | `GET .../chapters/{n}` |
+| `useVerseHighlightService` | Bible (client) | localStorage — sem API |
+| `useSupportService` | Help | `POST support` (FormData) |
+
+Detalhes dos endpoints bíblicos: [Catalog and metadata](../domains/bible/catalog-and-metadata.md).
+
+## Adicionar um resource novo
+
+1. Schema Zod em `app/types/<entity>/`.
+2. `useXService.ts` em `composables/services/`.
+3. GETs SSR → `useApiFetch`; mutações → `useApi()`.
+4. Consumir na page ou composable do **domínio** — não chamar `$fetch` direto.
+
+## Erros
+
+- `createAppError()` (`app/utils/errors.ts`) — falhas user-facing; `fatal` no client.
+- Bootstrap sem dados: layout lança erro cedo ([App shell](./app-shell.md)).
+- Capítulo ausente: page trata `null` com UI — ver [Chapter reader](../domains/bible/chapter-reader.md).
+
+## Variáveis de ambiente
+
+| Variável | Uso |
+|----------|-----|
+| `NUXT_PUBLIC_API_BASE_URL` | Browser |
+| `NUXT_API_BASE_URL` | SSR / Docker |
+| `NUXT_API_KEY` | Server only |
+
+Validação: `app/utils/env.ts` → `nuxt.config.ts`.

--- a/docs/core/persistence-patterns.md
+++ b/docs/core/persistence-patterns.md
@@ -1,0 +1,89 @@
+# Persistence patterns
+
+Regras **genéricas** para estado e armazenamento. Dados concretos de cada domínio ficam nos docs do domínio.
+
+## Três mecanismos
+
+| Mecanismo | Quando usar | SSR-safe? |
+|-----------|-------------|-----------|
+| **Pinia** | Estado reativo compartilhado na sessão | Sim (com hidratação) |
+| **Cookie** (`useCookie`) | Preferências que sobrevivem reload; opcionalmente SSR | Sim |
+| **localStorage** | Dados só client, volume maior | **Não** — guard `import.meta.client` |
+
+## Pinia
+
+- Arquivo: `stores/<name>Store.ts`, id curto (`'version'`).
+- Export: `useXStore()` — auto-import Nuxt.
+- Mutations explícitas (`setVersions`, `setLastChapter`); evite mutar refs de fora.
+- Stores atuais e **qual domínio** os dona:
+
+| Store | Domínio | Doc |
+|-------|---------|-----|
+| `versionStore` | Bible | [Catalog and metadata](../domains/bible/catalog-and-metadata.md) |
+| `lastChapterStore` | Bible | [Reading history](../domains/bible/reading-history.md) |
+
+## Cookies
+
+Padrão no projeto:
+
+```ts
+useCookie<string | null>('cookie-name', { maxAge: 60 * 60 * 24 * 365 })
+```
+
+| Cookie | Domínio | Definido em |
+|--------|---------|-------------|
+| `current-version-name` | Bible | `versionStore` |
+| `last-chapter-reference` | Bible | `lastChapterStore` |
+| `bible-font-size`, `bible-font-family` | Bible | `BibleChapter` |
+| `theme` | Core | `@nuxtjs/color-mode` |
+
+## localStorage
+
+Padrão obrigatório:
+
+1. Schema Zod em `app/types/`.
+2. Service ou composable encapsula read/write.
+3. `if (!import.meta.client) return` em escritas.
+4. JSON inválido → remover chave, retornar vazio.
+
+Exemplos no domínio Bible: [Verses and placeholders](../domains/bible/verses-and-placeholders.md), [Reading history](../domains/bible/reading-history.md).
+
+## Onde persistir feature nova
+
+| Tipo de dado | Escolha |
+|--------------|---------|
+| UI efêmera (modal aberto, seleção temporária) | `ref` local no componente |
+| Preferência global simples | Cookie |
+| Estado compartilhado entre rotas | Pinia (+ cookie se precisar sobreviver reload) |
+| Anotações só client | localStorage + Zod |
+| Sync entre dispositivos | Backend (ainda não usado para highlights) |
+
+## Estado que **não** vai para store global
+
+Exemplos Bible (detalhes nos docs do domínio):
+
+- Versículos selecionados — local ao `BibleChapter`, reset no remount.
+- Foco de versículo — derivado do hash da URL.
+- Query do SearchModal — refs locais.
+
+## Diagrama
+
+```mermaid
+flowchart LR
+  subgraph corePatterns [Core patterns]
+    Pinia[Pinia stores]
+    Cookie[useCookie]
+    LS[localStorage + Zod]
+  end
+
+  subgraph bible [Bible domain data]
+    VS[versionStore]
+    LC[lastChapterStore]
+    VH[verse-highlights]
+    CH[chapter-history]
+  end
+
+  Pinia --> VS & LC
+  LS --> VH & CH
+  Cookie --> VS & LC
+```

--- a/docs/core/routing-overview.md
+++ b/docs/core/routing-overview.md
@@ -1,0 +1,45 @@
+# Routing overview
+
+Mapa de rotas file-based (`app/pages/`). Detalhes de URL bíblica ficam no domínio Bible.
+
+## Rotas
+
+| Rota | Arquivo | Domínio | Comportamento |
+|------|---------|---------|---------------|
+| `/` | `pages/index.vue` | [Home](../domains/home/landing-page.md) | Landing marketing |
+| `/bible` | `pages/bible/index.vue` | [Bible](../domains/bible/overview.md) | Redirect → último capítulo ou João 1 |
+| `/bible/[reference]` | `pages/bible/[reference]/index.vue` | Bible | Leitor de capítulo |
+| `/help` | `pages/help/index.vue` | [Help](../domains/help/help-center.md) | Central de ajuda |
+
+## Layout compartilhado
+
+Todas as rotas usam `layouts/default.vue` ([App shell](./app-shell.md)).
+
+Não há layouts aninhados por domínio hoje — oportunidade futura para isolar bootstrap Bible.
+
+## Navegação entre domínios
+
+| De | Para | Mecanismo |
+|----|------|-----------|
+| Home | Bible | `useNavigateToBible().lastChapterUrl` |
+| Header | Bible | Links + SearchModal |
+| Header | Help | `RouterLink` / dropdown |
+| Help | Home | Botão voltar |
+| Bible | — | Nav interna prev/next capítulo |
+
+`useNavigateToBible` vive em `composables/` (não em `bible/`) porque Home também consome — mas a **semântica** é domínio Bible: [urls-and-references.md](../domains/bible/urls-and-references.md).
+
+## Adicionar rota nova
+
+1. Criar `pages/<rota>/index.vue`.
+2. Decidir domínio → criar doc em `docs/domains/<nome>/` se não existir.
+3. SEO: `useSeoMeta` na page + entrada no sitemap se indexável ([SEO](./seo.md)).
+4. Se a rota precisar de dados globais, evitar depender de `versionStore` a menos que seja feature bíblica.
+
+## Nitro / server routes
+
+| Rota | Arquivo | Propósito |
+|------|---------|-----------|
+| Sitemap URLs | `server/api/__sitemap__/urls.ts` | Feed `@nuxtjs/seo` |
+
+Lógica pura extraída para testabilidade — ver [SEO](./seo.md) e [Catalog](../domains/bible/catalog-and-metadata.md).

--- a/docs/core/seo.md
+++ b/docs/core/seo.md
@@ -1,0 +1,55 @@
+# SEO
+
+Padrões de SEO **transversais**. Copy e schema específicos ficam em cada page/domínio.
+
+## Stack
+
+- `@nuxtjs/seo` — sitemap, helpers
+- `useSeoMeta`, `useHead`, `useSchemaOrg` nas pages
+- PWA: `@vite-pwa/nuxt` em `nuxt.config.ts`
+- Analytics: `nuxt-gtag`, `nuxt-clarity-analytics`
+
+## Camadas de meta
+
+| Camada | Onde | O que define |
+|--------|------|--------------|
+| Global | `layouts/default.vue` | og:image, twitter card, canonical |
+| Por page | `pages/*/index.vue` | title, description, schema específico |
+
+### Pages existentes
+
+| Page | Schema destacado |
+|------|------------------|
+| `/` | `WebSite`, `WebPage`, `ItemList` — [Home](../domains/home/landing-page.md) |
+| `/bible/[reference]` | `WebPage`, `Article` — [Chapter reader](../domains/bible/chapter-reader.md) |
+| `/help` | `FAQPage` — [Help center](../domains/help/help-center.md) |
+
+Idioma visível e meta: **pt-BR** (`inLanguage: 'pt-BR'` onde aplicável).
+
+## Sitemap
+
+**Nitro:** `server/api/__sitemap__/urls.ts` → `defineSitemapEventHandler`.
+
+**Lógica pura:** `app/utils/bible/sitemapUrls.ts` — função `buildSitemapEntries()`.
+
+Entradas hoje:
+
+| `loc` | Origem |
+|-------|--------|
+| `/`, `/help` | Fixas na função |
+| `/bible/{book}.{chapter}` | Loop em `BOOKS` — domínio Bible |
+
+Detalhes das URLs de capítulo: [Catalog and metadata](../domains/bible/catalog-and-metadata.md).
+
+Testes: `test/unit/utils/bible/sitemapUrls.test.ts` (unit, sem Nuxt).
+
+## Checklist: nova page indexável
+
+1. `useSeoMeta` com title/description pt-BR.
+2. Schema.org se fizer sentido (FAQ, Article, etc.).
+3. Entrada em `buildSitemapEntries()` se deve aparecer no sitemap.
+4. Canonical já vem do layout — não duplicar salvo exceção.
+
+## Checklist: mudança de URL Bible
+
+Ver [urls-and-references.md](../domains/bible/urls-and-references.md) — sitemap, parsers e testes.

--- a/docs/domains/bible/catalog-and-metadata.md
+++ b/docs/domains/bible/catalog-and-metadata.md
@@ -1,0 +1,93 @@
+# Catalog and metadata
+
+Catálogo de versões/livros, metadados estáticos e bootstrap de dados bíblicos.
+
+## Metadados estáticos — `book.ts`
+
+`app/utils/bible/book.ts` — array `BOOKS`:
+
+```ts
+['gen', 'Gênesis', 50],  // [abbr, nome pt-BR, qtd capítulos estática]
+```
+
+| Export | Uso |
+|--------|-----|
+| `BookAbbreviation` / `BookAbbreviationType` | Enums Zod, rotas |
+| `getBookAbbreviation(key)` | Parse de URL |
+| `getDefaultBookName`, `getDefaultBookChapterCount` | Fallbacks estáticos |
+
+### Estático vs API
+
+| Cenário | Fonte |
+|---------|-------|
+| URLs, sitemap, validação de rota | `book.ts` |
+| Nome do livro na versão atual, capítulos disponíveis | API → `versionStore.currentVersionBooks` |
+| Capítulo existe? | API → null → `ChapterNotFound` |
+
+## `versionStore`
+
+`app/stores/versionStore.ts` — Pinia global, **dados Bible**.
+
+| Estado | Descrição |
+|--------|-----------|
+| `versions` | Todas as versões (API) |
+| `currentVersion` | Versão ativa + cookie `current-version-name` |
+| `currentVersionBooks` | Livros e capítulos da versão |
+| `allChapters` | Flat list — nav prev/next no leitor |
+
+Resolução da versão inicial (`setVersions`):
+
+1. Cookie `current-version-name`
+2. `NUXT_PUBLIC_DEFAULT_VERSION_ABBREVIATION`
+3. Primeira versão da API
+
+Mutators: `setCurrentVersion`, `setCurrentVersionBooks`, `setCurrentVersionWithBooks`.
+
+## Bootstrap no layout
+
+```mermaid
+sequenceDiagram
+  participant L as default.vue
+  participant VS as useVersionService
+  participant BS as useBookService
+  participant Store as versionStore
+
+  L->>VS: GET versions
+  L->>Store: setVersions
+  L->>BS: GET books(currentVersion.id)
+  L->>Store: setCurrentVersionBooks
+```
+
+Sem backend → `createAppError`. Acoplamento com plataforma: [Bible overview](./overview.md).
+
+### Versão diferente na URL
+
+Page `[reference]` detecta mismatch, chama `bookService.useIndex(version.id, false)` e `setCurrentVersionWithBooks`.
+
+## Services de catálogo
+
+| Service | Método | Endpoint |
+|---------|--------|----------|
+| `useVersionService` | `useIndex()` | `GET versions` |
+| `useBookService` | `useIndex(id)`, `index(id)` | `GET versions/{id}/books` |
+| `useChapterService` | `useShow(...)` | capítulo completo — [Chapter reader](./chapter-reader.md) |
+
+HTTP patterns: [HTTP layer](../../core/http-layer.md).
+
+## Sitemap — entradas de capítulo
+
+`app/utils/bible/sitemapUrls.ts` — `buildSitemapEntries()`:
+
+- `/`, `/help` (fixas)
+- `/bible/{abbr}.{chapter}` para cada livro × capítulo em `BOOKS`
+
+Sem versão na URL do sitemap. Nitro: `server/api/__sitemap__/urls.ts`.
+
+SEO geral: [SEO](../../core/seo.md). Testes: `test/unit/utils/bible/sitemapUrls.test.ts`.
+
+## Checklist: novo livro
+
+1. `BOOKS` em `book.ts`
+2. Schemas Zod com `z.enum(BookAbbreviation)`
+3. Rodar testes `book.test.ts`, `sitemapUrls.test.ts`
+4. Alinhar abreviação com backend

--- a/docs/domains/bible/chapter-reader.md
+++ b/docs/domains/bible/chapter-reader.md
@@ -1,0 +1,87 @@
+# Chapter reader
+
+Fluxo da rota `/bible/[reference]` e componente `BibleChapter`.
+
+## Page — `pages/bible/[reference]/index.vue`
+
+1. Parse — [urls-and-references.md](./urls-and-references.md)
+2. Sync versão URL ↔ `versionStore` — [catalog-and-metadata.md](./catalog-and-metadata.md)
+3. Fetch — `useChapterService().useShow`
+4. `lastChapterStore.setLastChapter` — [reading-history.md](./reading-history.md)
+5. SEO dinâmico (`useSeoMeta`, `useSchemaOrg`)
+6. Template: seletor + `BibleChapter` ou `ChapterNotFound`
+
+| Condição | UI |
+|----------|-----|
+| `chapterData` ok | `BibleChapter` |
+| `chapterData` null | `BibleChapterNotFound` |
+| Troca de rota | `isLoading` + blur |
+
+### SEO do capítulo
+
+- Title: `{Livro} {Cap} | {Versão}`
+- Schema: `WebPage` + `Article`, `inLanguage: 'pt-BR'`
+
+## Componente `BibleChapter`
+
+`app/components/bible/chapter/index.vue` → `<BibleChapter>`
+
+### Props
+
+```ts
+{ chapter: Chapter, isLoading: boolean }
+```
+
+### Subcomponentes
+
+| Componente | Papel |
+|------------|-------|
+| `BibleChapterHeader` | Título, versão, fonte |
+| `BibleChapterVerse` | Versículo (seleção, highlight, foco) |
+| `BibleChapterTitle` | Títulos start/end |
+| `BibleChapterFooter` | Rodapé |
+| `BibleSelectedVerses` | Painel de seleção |
+| `BibleVerseSelectorResponsivePanel` | Nav livro/cap — [search-and-selector.md](./search-and-selector.md) |
+
+### Prev / next
+
+`versionStore.allChapters` → índice → `getChapterUrl()` sem versão.
+
+### Preferências (cookies)
+
+| Cookie | Default |
+|--------|---------|
+| `bible-font-size` | `text-lg` |
+| `bible-font-family` | `font-sans` |
+
+### Troca de versão in-page
+
+`handleVersionSelect`: set version → `bookService.index` → reload books → `goToChapter` (mesmo livro/cap/verse).
+
+### Fullscreen
+
+`useBibleFullscreen` — page aplica `fixed inset-0 z-50` no `<main>`.
+
+## Tipos
+
+`app/types/chapter/Chapter.schema.ts` — `verses[]` com `titles`, `references` → [verses-and-placeholders.md](./verses-and-placeholders.md).
+
+## Fluxo de dados
+
+```mermaid
+flowchart LR
+  API[GET chapter] --> Page[reference/index.vue]
+  Page --> BC[BibleChapter]
+  BC --> VF[useVerseFocus]
+  BC --> SV[useSelectedVerses]
+  BC --> VH[useVerseHighlights]
+  BC --> CH[useChapterHistory]
+  VS[versionStore.allChapters] --> BC
+```
+
+## Implementar no leitor
+
+- Header → `ChapterHeader.vue`
+- Ação por versículo → `Verse.vue` + composable
+- Campo API novo → schemas Zod primeiro
+- Highlights keyed por `chapterKey`; seleção reseta no remount

--- a/docs/domains/bible/overview.md
+++ b/docs/domains/bible/overview.md
@@ -1,0 +1,96 @@
+# Bible domain — overview
+
+O domínio **Bible** cobre leitura, navegação entre livros/capítulos/versículos, catálogo de versões e features client-side do leitor (highlights, histórico).
+
+## Fronteira do domínio
+
+```mermaid
+flowchart TB
+  subgraph core [Core - shared]
+    Shell[default.vue shell]
+    HTTP[useApiFetch / services]
+    UI[Icon, themes, header]
+  end
+
+  subgraph bible [Bible domain]
+    Pages[pages/bible/]
+    Composables[composables/bible/]
+    Components[components/bible/]
+    Utils[utils/bible/]
+    Types[types/chapter, verse, book, ...]
+    Stores[versionStore, lastChapterStore]
+  end
+
+  subgraph other [Other domains]
+    Home[home/]
+    Help[help/]
+  end
+
+  Shell -->|bootstraps catalog| Stores
+  Shell -->|hosts modal| Components
+  Home -->|lastChapterUrl| Composables
+  Help -->|documents| Components
+  bible --> HTTP
+  bible --> UI
+```
+
+## Mapa de código
+
+| Área | Caminho | Responsabilidade |
+|------|---------|------------------|
+| Rotas | `app/pages/bible/` | Redirect `/bible`, leitor `[reference]` |
+| Composables | `app/composables/bible/` | Referências, versículos, histórico, fullscreen |
+| Navegação shared | `app/composables/useNavigateToBible.ts` | URLs e `navigateTo` — usado também por Home |
+| Services | `app/composables/services/use*Service.ts` | API REST (version, book, chapter, highlight) |
+| Componentes | `app/components/bible/` | Leitor, busca, seletor, seleção |
+| Metadados estáticos | `app/utils/bible/` | `book.ts`, placeholders, sitemap entries |
+| Stores | `app/stores/versionStore.ts`, `lastChapterStore.ts` | Catálogo + preferências de leitura |
+| Tipos | `app/types/book`, `chapter`, `verse`, … | Schemas Zod da API bíblica |
+
+## Sub-documentos
+
+| Tópico | Doc |
+|--------|-----|
+| URLs, parsing, hash | [urls-and-references.md](./urls-and-references.md) |
+| Page e componente do capítulo | [chapter-reader.md](./chapter-reader.md) |
+| Texto, seleção, highlights | [verses-and-placeholders.md](./verses-and-placeholders.md) |
+| Busca e seletor | [search-and-selector.md](./search-and-selector.md) |
+| Livros, versões, bootstrap | [catalog-and-metadata.md](./catalog-and-metadata.md) |
+| Histórico e último capítulo | [reading-history.md](./reading-history.md) |
+
+## Acoplamento com a plataforma
+
+### Bootstrap no layout (decisão atual)
+
+`layouts/default.vue` chama `useVersionService` e `useBookService` **antes** do `<slot />`. Isso significa:
+
+- `/`, `/help` e `/bible` só renderizam com backend + catálogo válido.
+- `versionStore.currentVersion` e `currentVersionBooks` existem em qualquer page.
+- Home e header podem usar versão/último capítulo sem fetch extra.
+
+**Se precisar desacoplar no futuro:** mover bootstrap para middleware ou layout aninhado só em `/bible/**`, e tornar catálogo lazy na home/help.
+
+### Modais globais bíblicos
+
+`BibleSearchModal` vive no layout ([App shell](../../core/app-shell.md)) porque a busca rápida (teclado) deve funcionar em qualquer rota. A **lógica** do modal é domínio Bible — ver [search-and-selector.md](./search-and-selector.md).
+
+### Stores “globais” com dados bíblicos
+
+`versionStore` e `lastChapterStore` são Pinia app-wide, mas o **conteúdo** é do domínio Bible. Outros domínios devem apenas **consumir** (ex.: link para último capítulo), não estender essas stores com campos de help/home.
+
+## Adicionar feature no domínio Bible
+
+1. Ler o sub-doc mais próximo (tabela acima).
+2. Colocar UI em `components/bible/`, lógica em `composables/bible/`.
+3. Novo endpoint → service em `composables/services/` + schema em `types/`.
+4. Nova abreviação de livro → `utils/bible/book.ts` + [catalog-and-metadata.md](./catalog-and-metadata.md).
+5. Testes em `test/unit/utils/bible/` ou `test/nuxt/` espelhando `app/`.
+
+## Fora deste domínio
+
+| Feature | Domínio / doc |
+|---------|----------------|
+| Landing, CTA, stats | [Home](../home/landing-page.md) |
+| FAQ, formulário suporte | [Help](../help/help-center.md) |
+| HTTP, `$api` | [HTTP layer](../../core/http-layer.md) |
+| Temas, header chrome | [Components and UI](../../core/components-and-ui.md) |

--- a/docs/domains/bible/reading-history.md
+++ b/docs/domains/bible/reading-history.md
@@ -1,0 +1,62 @@
+# Reading history
+
+Último capítulo lido e histórico de navegação — persistência client do domínio Bible.
+
+## Último capítulo — `lastChapterStore`
+
+`app/stores/lastChapterStore.ts`
+
+**Cookie:** `last-chapter-reference` — `{book}.{chapter}[.{version}]`
+
+| Campo | Exemplo |
+|-------|---------|
+| `book` | `jhn` |
+| `chapter` | `3` |
+| `version` | `acf` (opcional) |
+
+| Consumidor | Uso |
+|------------|-----|
+| `/bible` redirect | `goToLastChapter(true)` |
+| `LastChapterLink`, header | Link rápido |
+| Home schema | `lastChapterUrl` no ItemList |
+
+Setado em `pages/bible/[reference]/index.vue` após capítulo carregar com sucesso.
+
+Parsing compartilha lógica com URLs — [urls-and-references.md](./urls-and-references.md).
+
+## Histórico de leitura — `useChapterHistory`
+
+`app/composables/bible/useChapterHistory.ts`
+
+| Aspecto | Valor |
+|---------|-------|
+| Storage | `localStorage` key `chapter-history` |
+| Máximo | 30 itens |
+| Validação | `chapterHistorySchema` (Zod) |
+| UI | `HistoryModal` no header do capítulo |
+
+Registro no `onMounted` de `BibleChapter`:
+
+```ts
+addToHistory({ book, chapter, verse?, versionName, timestamp })
+```
+
+## Padrões de persistência
+
+Seguem [Persistence patterns](../../core/persistence-patterns.md):
+
+- Guard client-only
+- JSON corrompido → limpar chave
+- Não participa de SSR
+
+## O que não persiste aqui
+
+| Feature | Onde |
+|---------|------|
+| Highlights | [Verses and placeholders](./verses-and-placeholders.md) |
+| Versículos selecionados | Estado local — reset no remount |
+| Versão preferida | `versionStore` cookie — [Catalog](./catalog-and-metadata.md) |
+
+## Sync futuro
+
+Histórico e último capítulo são **device-local**. Conta de usuário / backend exigiria novo service e revisão de stores — manter interfaces dos composables se possível.

--- a/docs/domains/bible/search-and-selector.md
+++ b/docs/domains/bible/search-and-selector.md
@@ -1,0 +1,56 @@
+# Search and selector
+
+Busca rápida de livro/capítulo/versículo e painel de navegação lateral — UI de descoberta do domínio Bible.
+
+## `BibleSearchModal`
+
+Arquivo: `app/components/bible/SearchModal.vue`
+
+Montado no **layout global** para atalho de teclado em qualquer rota ([App shell](../../core/app-shell.md)).
+
+### Fluxo em 3 passos
+
+1. **Livro** — autocomplete por prefixo do nome (`normalizeString` + `versionStore.currentVersionBooks`)
+2. **Capítulo** — lista capítulos do livro selecionado
+3. **Versículo** (opcional) — valida contra `verses_count`
+
+Auto-seleciona livro quando a busca retorna um único resultado.
+
+### API pública
+
+```ts
+searchModalRef.value?.open(initialChar?)  // exposto via defineExpose + ref no layout
+```
+
+`initialChar` pré-preenche o campo livro (ex.: `g` → Gênesis).
+
+## Atalho de teclado
+
+Handler em `layouts/default.vue` (client only):
+
+| Condição | Ação |
+|----------|------|
+| Foco em input | ignorado |
+| Ctrl/Alt/Shift/Meta | ignorado |
+| `[a-zA-Z1-3]` | `searchModalRef.open(char)` |
+
+## `BibleVerseSelectorResponsivePanel`
+
+`app/components/bible/verse_selector/`
+
+- Painel lateral (desktop) / drawer (mobile) na page do capítulo
+- Navegação por livro e capítulo usando `versionStore.currentVersionBooks`
+- Complementa SearchModal — mesma fonte de dados (catálogo)
+
+## Dependências
+
+| Dado | Fonte |
+|------|-------|
+| Lista de livros/capítulos | `versionStore` — [Catalog and metadata](./catalog-and-metadata.md) |
+| Navegação após seleção | `useNavigateToBible` — [URLs and references](./urls-and-references.md) |
+
+## Implementar melhorias de busca
+
+- Lógica de filtro → manter no modal ou extrair composable `useBibleSearch` se crescer
+- Nova tecla de atalho → `default.vue` + documentar conflitos com inputs
+- Busca por texto de versículo (full-text) → **novo** endpoint + service; não misturar no modal atual de referência

--- a/docs/domains/bible/urls-and-references.md
+++ b/docs/domains/bible/urls-and-references.md
@@ -1,0 +1,86 @@
+# URLs and references
+
+Formato de URL, parsing e navegação programática do domínio Bible.
+
+## Formato
+
+```
+/bible/{book}.{chapter}[.{version}][#v{number}]
+```
+
+| Segmento | Exemplo | Obrigatório | Descrição |
+|----------|---------|-------------|-----------|
+| `book` | `gn`, `jhn`, `1co` | Sim | Abreviação em `app/utils/bible/book.ts` |
+| `chapter` | `1`, `150` | Sim | Número inteiro |
+| `version` | `acf`, `nvi` | Não | Omitida = versão atual (`versionStore`) |
+| `#vN` | `#v16` | Não | Foco no versículo N (N > 1) |
+
+**Exemplos:** `/bible/jhn.3` · `/bible/jhn.3.acf` · `/bible/psa.23.nvi#v4`
+
+## Parsing — `useBibleReference`
+
+`app/composables/bible/useBibleReference.ts`
+
+```ts
+const [bookParam, chapterParam, versionNameParam] = reference.split('.')
+```
+
+1. Livro via `getBookAbbreviation()` — inválido → fallback **`jhn`**
+2. Capítulo: `Number(chapterParam) || 1`
+3. Versão: param URL ou `versionStore.currentVersion`
+4. Sem versão → `createAppError('A versão não foi encontrada')`
+
+## Navegação — `useNavigateToBible`
+
+`app/composables/useNavigateToBible.ts` (fora de `composables/bible/` porque Home também usa)
+
+| API | Uso |
+|-----|-----|
+| `getChapterUrl(book, chapter, version?, verse?)` | Monta path + hash |
+| `goToChapter(...)` | `navigateTo` |
+| `goToLastChapter(replace?)` | Cookie ou João 1 |
+| `lastChapterUrl` | Link na home/header |
+
+Nav interna (prev/next) **omite** versão na URL — usuário permanece na versão do store/cookie.
+
+## Fluxo ao mudar capítulo
+
+```mermaid
+sequenceDiagram
+  participant P as pages/bible/[reference]
+  participant BR as useBibleReference
+  participant VS as versionStore
+  participant CS as useChapterService
+
+  P->>BR: parse
+  BR->>VS: resolve version
+  alt URL version ≠ current
+    P->>VS: setCurrentVersionWithBooks
+  end
+  P->>CS: useShow
+  P->>P: lastChapterStore + SEO
+```
+
+## Hash `#vN`
+
+- Lido em `BibleChapter` → `useVerseFocus`
+- Scroll suave + overlay; v1 ou capítulo curto → sem overlay
+- Limpar foco → `history.replaceState` remove hash
+
+Detalhes de render: [Verses and placeholders](./verses-and-placeholders.md).
+
+## Rotas Bible
+
+| Rota | Arquivo |
+|------|---------|
+| `/bible` | `pages/bible/index.vue` — só `goToLastChapter(true)` |
+| `/bible/[reference]` | `pages/bible/[reference]/index.vue` |
+
+Mapa geral: [Routing overview](../../core/routing-overview.md).
+
+## Ao mudar URLs
+
+1. `useNavigateToBible` / `useBibleReference`
+2. `utils/bible/sitemapUrls.ts` + [Catalog and metadata](./catalog-and-metadata.md)
+3. Testes unit em `test/unit/utils/bible/`
+4. Buscar `/bible/` em copy e SEO

--- a/docs/domains/bible/verses-and-placeholders.md
+++ b/docs/domains/bible/verses-and-placeholders.md
@@ -1,0 +1,74 @@
+# Verses and placeholders
+
+Renderização, seleção, cópia e highlights de versículos.
+
+## Placeholders no texto
+
+| Marcador | Significado |
+|----------|-------------|
+| `{{slug}}` | Referência cruzada |
+| `[[slug]]` | Título inline |
+
+Fonte: `app/utils/bible/versePlaceholders.ts`
+
+### `useProcessedVerseParts`
+
+`app/composables/bible/useProcessedVerseParts.ts` → partes `text` | `reference` | `title`.
+
+Usado em `Verse.vue`, `Title.vue`.
+
+### Títulos de seção
+
+`Verse.titles[]` com `position: 'start' | 'end'` → `BibleChapterTitle`.
+
+### Cópia plain text
+
+`stripVersePlaceholders()` antes do clipboard.
+
+## Seleção — `useSelectedVerses`
+
+| API | Descrição |
+|-----|-----------|
+| `toggleVerse(n)` | Toggle seleção |
+| `hasSelection` | Painel `BibleSelectedVerses` |
+| `formattedReference(book, chapter)` | Ex.: `João 3:16-18` |
+| `copySelectedVerses(params)` | Texto + ref + URL |
+
+`formatVerseReference([1,2,3,5])` → `"1-3,5"` — testes em `test/unit/`.
+
+## Highlights
+
+- Service: `useVerseHighlightService` (localStorage)
+- Composable: `useVerseHighlights(chapterKey, selectedVerses)`
+- Chave: `{book}.{chapter}.{version}` uppercase — ex. `JHN.3.ACF`
+- Schema: `verseHighlightsStorageSchema`
+
+Persistência: [Persistence patterns](../../core/persistence-patterns.md).
+
+## Foco — hash `#vN`
+
+`useVerseFocus` + `id="v{n}"` em `Verse.vue`. Ver [urls-and-references.md](./urls-and-references.md).
+
+## Referências cruzadas
+
+`VerseReference.vue` + tipo `VerseReference` → navega com `useNavigateToBible`.
+
+## Diagrama
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Selected: click
+  Selected --> Highlighted: cor
+  Idle --> Focused: hash #vN
+  Focused --> Idle: scroll/overlay
+```
+
+## Onde mexer
+
+| Feature | Arquivos |
+|---------|----------|
+| Novo placeholder | `versePlaceholders.ts`, `useProcessedVerseParts` |
+| Painel seleção | `SelectedVerses.vue`, `useSelectedVerses` |
+| Highlight | `useVerseHighlightService`, UI de cores |
+| Tooltip ref | `VerseReference.vue` |

--- a/docs/domains/help/help-center.md
+++ b/docs/domains/help/help-center.md
@@ -1,0 +1,80 @@
+# Help center
+
+Domínio **Help** — rota `/help`, documentação in-app e suporte.
+
+## Rota e arquivo
+
+| Rota | Arquivo |
+|------|---------|
+| `/help` | `app/pages/help/index.vue` |
+
+## Estrutura da page
+
+Single page com âncoras internas:
+
+| Seção (componente) | `#anchor` | Conteúdo |
+|------------------|-----------|----------|
+| `HelpSuggestionsBugs` | `#suggestions-bugs` | Abrir modal de suporte |
+| `HelpCustomization` | `#customization` | Temas e versões |
+| `HelpSearch` | `#search` | Como usar busca Bible |
+| `HelpFAQ` | `#faq` | Perguntas frequentes |
+| `HelpFutureFeatures` | `#future-features` | Roadmap |
+
+Navegação rápida: grid de cards no topo com `navigationItems`.
+
+Pasta: `app/components/help/`.
+
+## Modal de suporte (global)
+
+| Arquivo | Papel |
+|---------|-------|
+| `components/help/support/SupportModal.vue` | UI do modal |
+| `components/help/support/SupportForm.vue` | Formulário |
+| `components/help/support/SupportAttachmentPreview.vue` | Preview de anexos |
+| `composables/useSupportModal.ts` | Registro + `open()` cross-route |
+
+Modal montado em `layouts/default.vue` — padrão [App shell](../../core/app-shell.md).
+
+Fluxo:
+
+1. Layout registra ref no mount.
+2. Header / seção Help chama `useSupportModal().open()`.
+
+## API de suporte
+
+`composables/services/useSupportService.ts`
+
+```ts
+create({ type, description, email?, files[] }) → POST support (FormData)
+```
+
+Usa [HTTP layer](../../core/http-layer.md) — `useApi().post` com `FormData` (sem JSON Content-Type).
+
+**Domínio Help** — não colocar lógica de suporte em `composables/bible/`.
+
+## SEO
+
+- `useSeoMeta` — Central de Ajuda pt-BR
+- `useSchemaOrg` — `FAQPage`
+
+Sitemap: entrada `/help` em `buildSitemapEntries()` — ver [SEO](../../core/seo.md).
+
+## Conteúdo vs Bible
+
+Seções como `HelpSearch` e `HelpCustomization` **documentam** features Bible mas vivem no domínio Help (copy estática). Implementação real:
+
+- Busca → [Bible search](../bible/search-and-selector.md)
+- Temas → [Components and UI](../../core/components-and-ui.md)
+- Versões → [Catalog](../bible/catalog-and-metadata.md)
+
+## Adicionar seção de ajuda
+
+1. Componente `Help<Nome>.vue` em `components/help/`.
+2. Entrada em `navigationItems` na page.
+3. Âncora `#kebab-case` consistente.
+4. Se precisar enviar dados ao backend → estender `useSupportService` ou novo service Help.
+
+## Fora deste domínio
+
+- Leitor e busca (implementação) → [Bible](../bible/overview.md)
+- Layout e modais globais → [App shell](../../core/app-shell.md)

--- a/docs/domains/home/landing-page.md
+++ b/docs/domains/home/landing-page.md
@@ -1,0 +1,72 @@
+# Landing page
+
+Domínio **Home** — rota `/`, marketing e entrada para o produto.
+
+## Rota e arquivo
+
+| Rota | Arquivo |
+|------|---------|
+| `/` | `app/pages/index.vue` |
+
+Layout compartilhado: [App shell](../../core/app-shell.md).
+
+## Estrutura da page
+
+Template compõe seções em ordem:
+
+| Componente | Papel |
+|------------|-------|
+| `HomeHeroSection` | Hero principal, CTA |
+| `HomeVerseOfTheDaySection` | Versículo do dia |
+| `HomeQuickAccessSection` | Atalhos (incl. link Bible) |
+| `HomeStatsSection` | Números / social proof |
+| `HomeFeaturesSection` | Lista de features |
+| `HomeCtaSection` | CTA final |
+| `HomePageFooter` | Rodapé da landing |
+
+Pasta: `app/components/home/`.
+
+## Versículo do dia
+
+| Arquivo | Papel |
+|---------|-------|
+| `app/data/verseOfTheDay.ts` | Lista estática `verses` com `day` (1–366) |
+| `app/composables/bible/useVerseOfTheDay.ts` | `getTodayVerse()`, `parsePassageId()` |
+
+Lógica Bible reutilizada na home — dados estáticos, **sem** chamada API no mount da landing.
+
+`parsePassageId` usa `getBookAbbreviation` de `utils/bible/book.ts` — links gerados apontam para rotas Bible.
+
+## Acoplamento com Bible
+
+| Uso | Mecanismo |
+|-----|-----------|
+| Link “continuar lendo” / Bíblia no schema | `useNavigateToBible().lastChapterUrl` |
+| Versículo do dia | Composable em `composables/bible/` |
+
+A home **não** carrega catálogo por conta própria — depende do bootstrap global ([Bible overview](../bible/overview.md)).
+
+## SEO
+
+Em `pages/index.vue`:
+
+- `useSeoMeta` — title/description pt-BR
+- `useSchemaOrg` — `WebSite`, `WebPage`, `ItemList` com links Início / Bíblia / Ajuda
+
+Detalhes: [SEO](../../core/seo.md).
+
+## Estilo
+
+Background com grid de pontos (`radial-gradient`) — variantes para temas escuros via `:global(html[data-theme=...])` no scoped CSS da page.
+
+## Adicionar seção na landing
+
+1. Novo SFC em `components/home/<Nome>Section.vue`.
+2. Importar na page (auto-import Nuxt).
+3. Strings pt-BR; comentários inglês.
+4. Se a seção precisar de API Bible, preferir composable existente ou link para `/bible` — evitar fetch pesado na `/`.
+
+## Fora deste domínio
+
+- Leitor, busca, catálogo → [Bible domain](../bible/overview.md)
+- Temas, header → [Components and UI](../../core/components-and-ui.md)

--- a/docs/testing/vitest.md
+++ b/docs/testing/vitest.md
@@ -1,0 +1,141 @@
+# Testing with Vitest
+
+Cross-cutting test infrastructure. Domain-specific test examples are noted per area in [`docs/domains/`](../domains/) and [`docs/core/`](../core/).
+
+Three **projects** in `vitest.config.ts`, aligned with [Nuxt Testing docs](https://nuxt.com/docs/getting-started/testing).
+
+## Projects
+
+| Project | Directory | Environment | When to use |
+|---------|-----------|-------------|-------------|
+| `unit` | `test/unit/` | Node | Pure functions, schemas, metadata — **no** Nuxt runtime |
+| `nuxt` | `test/nuxt/` | Nuxt + happy-dom | DOM composables, components, auto-imports |
+| `e2e` | `test/e2e/` | Node + Nuxt server | Full SSR, Nitro routes — **slow** (~45s+ setup) |
+
+## Commands
+
+```bash
+npm test              # all projects
+npm run test:unit     # fast — prefer during development
+npm run test:nuxt
+npm run test:e2e
+npm run test:watch
+```
+
+In Docker (preferred):
+
+```bash
+docker compose exec bible_frontend npm test
+```
+
+## Mirroring `app/`
+
+Test paths mirror source:
+
+```
+app/utils/bible/book.ts          → test/unit/utils/bible/book.test.ts
+app/utils/helpers.ts             → test/unit/utils/helpers.test.ts
+app/utils/bible/sitemapUrls.ts   → test/unit/utils/bible/sitemapUrls.test.ts
+```
+
+## `~/` alias
+
+Configured in `vitest.config.ts` pointing to `./app`:
+
+```ts
+import { formatVerseReference } from '~/composables/bible/useSelectedVerses'
+```
+
+Works in **unit** and **nuxt**; unit **does not** have Nuxt auto-imports (`useRoute`, etc.).
+
+## Test environment
+
+File: `.env.test` (committed — fake values only).
+
+Loaded automatically by Vitest. CI may override via secrets.
+
+## Best practices by type
+
+### Unit (`test/unit/`)
+
+**Good for:**
+
+- `formatVerseReference`, `getBookAbbreviation`, `buildSitemapEntries`
+- Zod parsing of JSON fixtures
+- Helpers in `app/utils/`
+
+**Avoid:** `mount`, `useFetch`, anything needing Pinia/Nuxt context.
+
+### Nuxt (`test/nuxt/`)
+
+**Good for:**
+
+- Vue components with auto-imports
+- Composables using `useRoute`, cookies, etc.
+
+**Helpers:**
+
+```ts
+import { mountSuspended, mockNuxtImport, registerEndpoint } from '@nuxt/test-utils/runtime'
+```
+
+- `mountSuspended` — mount with Nuxt context
+- `mockNuxtImport('useVersionStore', () => ...)` — mock stores
+- `registerEndpoint('/api/...', () => mockData)` — mock Nitro API
+
+**Rule:** do not mix `@nuxt/test-utils/runtime` and `@nuxt/test-utils/e2e` in the same file.
+
+### E2E (`test/e2e/`)
+
+**Good for:**
+
+- Verifying real page SSR
+- Nitro routes end-to-end
+
+**Caution:** pages using `layouts/default.vue` need a backend or mocks for all bootstrap endpoints.
+
+**Prefer unit** for `server/api/__sitemap__/urls.ts` logic — extracted to `app/utils/bible/sitemapUrls.ts` for that reason.
+
+## CI
+
+`.github/workflows/ci.yml`:
+
+1. `npx nuxt typecheck`
+2. `npm test`
+3. `npm run build`
+
+## Adding tests for a new feature
+
+```mermaid
+flowchart TD
+  A[New code] --> B{Pure function?}
+  B -->|Yes| C[test/unit/]
+  B -->|No| D{Needs DOM or auto-import?}
+  D -->|Yes| E[test/nuxt/]
+  D -->|No| F{Needs real SSR?}
+  F -->|Yes| G[test/e2e/]
+  F -->|No| C
+```
+
+1. Write tests in the cheapest project possible.
+2. Name `*.test.ts` or `*.spec.ts`.
+3. Keep fixtures small and inline, or colocate if large.
+4. Do not test trivial implementation (obvious getters, re-exports).
+
+## Existing examples
+
+| File | Validates |
+|------|-----------|
+| `test/unit/utils/bible/book.test.ts` | Book metadata |
+| `test/unit/utils/bible/sitemapUrls.test.ts` | URL count and format |
+| `test/unit/formatVerseReference.test.ts` | Verse range grouping |
+| `test/nuxt/utils/helpers.test.ts` | Helpers with Nuxt context |
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `useX is not defined` in unit | Move to nuxt or import explicitly |
+| Fetch fails in e2e | Mock endpoints or start backend |
+| Slow test | Move logic to `utils/` and test in unit |
+| Env missing | Check `.env.test` and `vitest.config.ts` |


### PR DESCRIPTION
Organize technical documentation under docs/core, docs/domains, and
docs/testing so shared infrastructure is separated from bible, home,
and help features.