### PR TITLE
feat: enhance verse focus functionality and improve verse reference interaction

### DIFF
--- a/app/components/bible/chapter/Verse.vue
+++ b/app/components/bible/chapter/Verse.vue
@@ -75,6 +75,7 @@ const onClick = (event: MouseEvent) => {
         <BibleChapterVerseReference
           v-else-if="part.type === 'reference'"
           :reference="part.reference"
+          :verse-number="verse.number"
         />
       </template>
     </div>

--- a/app/components/bible/chapter/VerseReference.vue
+++ b/app/components/bible/chapter/VerseReference.vue
@@ -1,11 +1,16 @@
 <script setup lang="ts">
 import type { VerseReference } from '~/types/verseReference/VerseReference.type'
+import { useVerseFocusContext } from '~/composables/bible/useVerseFocusContext'
 
 const props = defineProps<{
   reference: VerseReference
+  verseNumber?: number
 }>()
 
+const { focusVerseByNumber, clearFocus } = useVerseFocusContext()
+
 const popoverRef = useTemplateRef('popoverRef')
+const isPopoverOpen = ref(false)
 
 const toggle = (event: Event) => {
   popoverRef.value?.toggle(event)
@@ -14,14 +19,34 @@ const toggle = (event: Event) => {
 const close = () => {
   popoverRef.value?.hide()
 }
+
+const handleShow = () => {
+  isPopoverOpen.value = true
+
+  if (props.verseNumber == null) return
+
+  focusVerseByNumber(props.verseNumber, false)
+}
+
+const handleHide = () => {
+  isPopoverOpen.value = false
+
+  if (props.verseNumber == null) return
+
+  clearFocus()
+}
 </script>
 
 <template>
   <div class="inline-flex relative -top-1">
     <button
       type="button"
-      class="group inline-flex items-center justify-center align-middle mx-1.5 p-1.5 rounded-md bg-base-100 text-base-content/60 hover:text-base-content/90 focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 cursor-pointer hover:bg-base-300 active:scale-95"
+      class="group inline-flex items-center justify-center align-middle mx-1.5 p-1.5 rounded-md cursor-pointer transition-all duration-200 focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 active:scale-95"
+      :class="isPopoverOpen
+        ? 'bg-base-200 text-base-content ring-2 ring-base-300 shadow-sm'
+        : 'bg-base-100 text-base-content/60 hover:text-base-content/90 hover:bg-base-300'"
       :aria-label="`Ver referência bíblica: ${reference.text}`"
+      :aria-expanded="isPopoverOpen"
       @click="toggle"
     >
       <Icon icon="file_text" class="w-[1em] h-[1em] transition-transform duration-200 group-hover:scale-110" />
@@ -31,6 +56,8 @@ const close = () => {
       ref="popoverRef"
       class="verse-reference-popover"
       :pt="{ content: { class: 'p-0! rounded-lg!' } }"
+      @show="handleShow"
+      @hide="handleHide"
     >
       <div class="min-w-xs max-w-sm">
         <div class="flex items-center justify-between bg-base-300 px-3 py-2 rounded-t-box">

--- a/app/components/bible/chapter/index.vue
+++ b/app/components/bible/chapter/index.vue
@@ -6,6 +6,7 @@ import { VerseTitlePositionEnum } from '~/types/verseTitle/verseTitle.schema'
 import { useVerseFocus } from '~/composables/bible/useVerseFocus'
 import { useSelectedVerses } from '~/composables/bible/useSelectedVerses'
 import { provideSelectedVersesContext } from '~/composables/bible/useSelectedVersesContext'
+import { provideVerseFocusContext } from '~/composables/bible/useVerseFocusContext'
 import { useVerseHighlights } from '~/composables/bible/useVerseHighlights'
 import { useChapterHistory } from '~/composables/bible/useChapterHistory'
 import { useBookService } from '~/composables/services/useBookService'
@@ -115,6 +116,7 @@ const {
   overlayHeight,
   handleScroll,
   handleVerseFocus,
+  focusVerseByNumber,
   clearFocus
 } = useVerseFocus(chapterContainerRef, verseNumber, clearHash)
 
@@ -198,6 +200,11 @@ provideSelectedVersesContext({
   bookAbbreviation: computed(() => props.chapter.book.abbreviation),
   chapterNumber: computed(() => props.chapter.number),
   bookName: computed(() => props.chapter.book.name),
+})
+
+provideVerseFocusContext({
+  focusVerseByNumber,
+  clearFocus,
 })
 
 </script>

--- a/app/composables/bible/useVerseFocus.ts
+++ b/app/composables/bible/useVerseFocus.ts
@@ -28,6 +28,21 @@ export const useVerseFocus = (
     if (verseNumber.value) onClearFocus?.()
   }
 
+  const focusVerseByNumber = (targetVerseNumber: number, shouldScrollIntoVerse = true) => {
+    if (!containerRef.value) return
+
+    const verseElement = containerRef.value.querySelector(`#v${targetVerseNumber}`)
+    if (!verseElement) return
+
+    focusedVerseNumber.value = targetVerseNumber
+
+    if (!shouldScrollIntoVerse) return
+
+    isScrollingToVerse = true
+    verseElement.scrollIntoView({ behavior: 'smooth' })
+    resetScrollTimeout()
+  }
+
   const focusVerse = () => {
     if (!verseNumber.value || !containerRef.value) return clearFocus()
 
@@ -38,13 +53,7 @@ export const useVerseFocus = (
       return clearFocus()
     }
 
-    const verseElement = container.querySelector(`#v${verseNumber.value}`)
-    if (!verseElement) return
-
-    isScrollingToVerse = true
-    focusedVerseNumber.value = verseNumber.value
-    verseElement.scrollIntoView({ behavior: 'smooth' })
-    resetScrollTimeout()
+    focusVerseByNumber(verseNumber.value)
   }
 
   const handleVerseFocus = () => {
@@ -64,6 +73,7 @@ export const useVerseFocus = (
     overlayHeight,
     handleScroll,
     handleVerseFocus,
+    focusVerseByNumber,
     clearFocus
   }
 }

--- a/app/composables/bible/useVerseFocusContext.ts
+++ b/app/composables/bible/useVerseFocusContext.ts
@@ -1,0 +1,20 @@
+export interface VerseFocusContext {
+  focusVerseByNumber: (verseNumber: number, shouldScrollIntoVerse?: boolean) => void
+  clearFocus: () => void
+}
+
+const VERSE_FOCUS_CONTEXT_KEY = Symbol('verseFocusContext') as InjectionKey<VerseFocusContext>
+
+export function provideVerseFocusContext(context: VerseFocusContext) {
+  provide(VERSE_FOCUS_CONTEXT_KEY, context)
+}
+
+export function useVerseFocusContext(): VerseFocusContext {
+  const context = inject(VERSE_FOCUS_CONTEXT_KEY)
+
+  if (!context) {
+    throw new Error('useVerseFocusContext must be used within a provider')
+  }
+
+  return context
+}

--- a/test/nuxt/components/bible/chapter/VerseReference.test.ts
+++ b/test/nuxt/components/bible/chapter/VerseReference.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mockComponent, mountSuspended } from '@nuxt/test-utils/runtime'
+import BibleChapterVerseReference from '~/components/bible/chapter/VerseReference.vue'
+import { provideVerseFocusContext } from '~/composables/bible/useVerseFocusContext'
+import type { VerseReference } from '~/types/verseReference/VerseReference.type'
+
+const reference: VerseReference = {
+  id: 1,
+  slug: 'ref-1',
+  text: 'Texto da referência bíblica.',
+}
+
+const triggerSelector = 'button[aria-label^="Ver referência bíblica"]'
+const closeSelector = 'button[aria-label="Fechar"]'
+
+mockComponent('Icon', {
+  props: ['icon'],
+  template: '<span />',
+})
+
+mockComponent('Popover', {
+  emits: ['show', 'hide'],
+  setup(_props, { slots, emit, expose }) {
+    expose({
+      toggle: () => emit('show'),
+      hide: () => emit('hide'),
+    })
+
+    return () => h('div', { class: 'popover-stub' }, slots.default?.())
+  },
+})
+
+async function mountVerseReference(verseNumber?: number) {
+  const focusVerseByNumber = vi.fn()
+  const clearFocus = vi.fn()
+
+  const Wrapper = defineComponent({
+    components: { BibleChapterVerseReference },
+    setup() {
+      provideVerseFocusContext({ focusVerseByNumber, clearFocus })
+    },
+    render() {
+      return h(BibleChapterVerseReference, {
+        reference,
+        verseNumber,
+      })
+    },
+  })
+
+  const wrapper = await mountSuspended(Wrapper)
+
+  return { wrapper, focusVerseByNumber, clearFocus }
+}
+
+describe('BibleChapterVerseReference', () => {
+  it('focuses the verse without scrolling when the popover opens', async () => {
+    const { wrapper, focusVerseByNumber } = await mountVerseReference(8)
+
+    await wrapper.find(triggerSelector).trigger('click')
+
+    expect(focusVerseByNumber).toHaveBeenCalledWith(8, false)
+  })
+
+  it('clears focus when the popover closes', async () => {
+    const { wrapper, clearFocus } = await mountVerseReference(8)
+
+    await wrapper.find(triggerSelector).trigger('click')
+    await wrapper.find(closeSelector).trigger('click')
+
+    expect(clearFocus).toHaveBeenCalledOnce()
+  })
+
+  it('does not focus a verse when verseNumber is omitted', async () => {
+    const { wrapper, focusVerseByNumber, clearFocus } = await mountVerseReference()
+
+    await wrapper.find(triggerSelector).trigger('click')
+    await wrapper.find(closeSelector).trigger('click')
+
+    expect(focusVerseByNumber).not.toHaveBeenCalled()
+    expect(clearFocus).not.toHaveBeenCalled()
+  })
+
+  it('marks the trigger button as expanded while the popover is open', async () => {
+    const { wrapper } = await mountVerseReference(8)
+    const button = wrapper.find(triggerSelector)
+
+    expect(button.attributes('aria-expanded')).toBe('false')
+
+    await button.trigger('click')
+
+    expect(button.attributes('aria-expanded')).toBe('true')
+    expect(button.classes()).toContain('ring-2')
+
+    await wrapper.find(closeSelector).trigger('click')
+
+    expect(button.attributes('aria-expanded')).toBe('false')
+    expect(button.classes()).not.toContain('ring-2')
+  })
+})

--- a/test/nuxt/composables/bible/useVerseFocus.test.ts
+++ b/test/nuxt/composables/bible/useVerseFocus.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, effectScope, h, nextTick, ref, type EffectScope, type Ref } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useVerseFocus } from '~/composables/bible/useVerseFocus'
+
+type ContainerOptions = {
+  scrollHeight?: number
+  clientHeight?: number
+  verseIds?: number[]
+}
+
+type SetupOptions = ContainerOptions & {
+  container?: HTMLElement | null
+  verseNumber?: number | null
+  onClearFocus?: () => void
+}
+
+function createContainer(options: ContainerOptions = {}) {
+  const {
+    scrollHeight = 500,
+    clientHeight = 100,
+    verseIds = [5],
+  } = options
+
+  const container = document.createElement('div')
+  Object.defineProperty(container, 'scrollHeight', { value: scrollHeight, configurable: true })
+  Object.defineProperty(container, 'clientHeight', { value: clientHeight, configurable: true })
+
+  for (const id of verseIds) {
+    const verse = document.createElement('div')
+    verse.id = `v${id}`
+    verse.scrollIntoView = vi.fn()
+    container.appendChild(verse)
+  }
+
+  return container
+}
+
+function getVerseElement(container: HTMLElement, id: number) {
+  return container.querySelector(`#v${id}`) as HTMLElement
+}
+
+function setupVerseFocus(options: SetupOptions = {}) {
+  const {
+    container,
+    verseNumber: initialVerseNumber = null,
+    onClearFocus,
+    scrollHeight,
+    clientHeight,
+    verseIds,
+  } = options
+
+  const resolvedContainer = container === undefined
+    ? createContainer({ scrollHeight, clientHeight, verseIds })
+    : container
+
+  const scope = effectScope()
+  const result = scope.run(() => {
+    const containerRef = ref(resolvedContainer)
+    const verseNumber = ref<number | null>(initialVerseNumber)
+    const composable = useVerseFocus(containerRef, verseNumber, onClearFocus)
+
+    return {
+      ...composable,
+      container: resolvedContainer,
+      containerRef,
+      verseNumber,
+      getVerseElement: (id: number) =>
+        resolvedContainer ? getVerseElement(resolvedContainer, id) : null,
+    }
+  })!
+
+  return { ...result, scope }
+}
+
+describe('useVerseFocus', () => {
+  let activeScope: EffectScope | undefined
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    activeScope?.stop()
+    activeScope = undefined
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  function useSetup(options: SetupOptions = {}) {
+    const setup = setupVerseFocus(options)
+    activeScope = setup.scope
+    const { scope: _scope, ...result } = setup
+    return result
+  }
+
+  describe('focusVerseByNumber', () => {
+    it('sets focusedVerseNumber when the verse element exists', () => {
+      const { focusedVerseNumber, focusVerseByNumber } = useSetup()
+
+      focusVerseByNumber(5, false)
+
+      expect(focusedVerseNumber.value).toBe(5)
+    })
+
+    it('does not scroll when shouldScrollIntoVerse is false', () => {
+      const { container, focusVerseByNumber } = useSetup()
+
+      focusVerseByNumber(5, false)
+
+      expect(getVerseElement(container!, 5).scrollIntoView).not.toHaveBeenCalled()
+    })
+
+    it('scrolls smoothly when shouldScrollIntoVerse is true', () => {
+      const { container, focusVerseByNumber } = useSetup()
+
+      focusVerseByNumber(5, true)
+
+      expect(getVerseElement(container!, 5).scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' })
+    })
+
+    it('does nothing when the container is missing', () => {
+      const { focusedVerseNumber, focusVerseByNumber } = useSetup({ container: null })
+
+      focusVerseByNumber(5, false)
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+
+    it('does nothing when the verse element is missing', () => {
+      const { focusedVerseNumber, focusVerseByNumber } = useSetup({ verseIds: [1] })
+
+      focusVerseByNumber(99, false)
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+  })
+
+  describe('clearFocus', () => {
+    it('clears focusedVerseNumber', () => {
+      const { focusedVerseNumber, focusVerseByNumber, clearFocus } = useSetup()
+
+      focusVerseByNumber(5, false)
+      clearFocus()
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+
+    it('calls onClearFocus when route verse number is set', () => {
+      const onClearFocus = vi.fn()
+      const { focusVerseByNumber, clearFocus } = useSetup({
+        verseNumber: 7,
+        onClearFocus,
+      })
+
+      focusVerseByNumber(5, false)
+      clearFocus()
+
+      expect(onClearFocus).toHaveBeenCalledOnce()
+    })
+
+    it('does not call onClearFocus when route verse number is missing', () => {
+      const onClearFocus = vi.fn()
+      const { focusVerseByNumber, clearFocus } = useSetup({ onClearFocus })
+
+      focusVerseByNumber(5, false)
+      clearFocus()
+
+      expect(onClearFocus).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('focusVerse', () => {
+    it('skips verse 1 from hash navigation', () => {
+      const { focusedVerseNumber, handleVerseFocus } = useSetup({
+        verseIds: [1],
+        verseNumber: 1,
+      })
+
+      handleVerseFocus()
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+
+    it('skips focus when the chapter does not scroll', () => {
+      const { focusedVerseNumber, handleVerseFocus } = useSetup({
+        scrollHeight: 100,
+        clientHeight: 100,
+        verseIds: [5],
+        verseNumber: 5,
+      })
+
+      handleVerseFocus()
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+
+    it('focuses and scrolls hash verses when scrolling is needed', () => {
+      const { container, focusedVerseNumber, handleVerseFocus } = useSetup({
+        verseIds: [5],
+        verseNumber: 5,
+      })
+
+      handleVerseFocus()
+
+      expect(focusedVerseNumber.value).toBe(5)
+      expect(getVerseElement(container!, 5).scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' })
+    })
+  })
+
+  describe('watch(verseNumber)', () => {
+    async function mountVerseFocusWatcher(options: {
+      verseIds?: number[]
+      initialVerseNumber?: number | null
+    } = {}) {
+      const container = createContainer({ verseIds: options.verseIds ?? [5] })
+      const state = {} as {
+        focusedVerseNumber: Ref<number | null>
+        verseNumber: Ref<number | null>
+      }
+
+      const TestComponent = defineComponent({
+        setup() {
+          const containerRef = ref(container)
+          const verseNumber = ref<number | null>(options.initialVerseNumber ?? null)
+          const { focusedVerseNumber } = useVerseFocus(containerRef, verseNumber)
+
+          state.focusedVerseNumber = focusedVerseNumber
+          state.verseNumber = verseNumber
+
+          return () => h('div')
+        },
+      })
+
+      await mountSuspended(TestComponent)
+
+      return { container, ...state }
+    }
+
+    it('focuses when route verse number is set', async () => {
+      const { container, focusedVerseNumber, verseNumber } = await mountVerseFocusWatcher()
+
+      verseNumber.value = 5
+      await nextTick()
+
+      expect(focusedVerseNumber.value).toBe(5)
+      expect(getVerseElement(container, 5).scrollIntoView).toHaveBeenCalledWith({ behavior: 'smooth' })
+    })
+
+    it('clears focus when route verse number is removed', async () => {
+      const { focusedVerseNumber, verseNumber } = await mountVerseFocusWatcher()
+
+      verseNumber.value = 5
+      await nextTick()
+      expect(focusedVerseNumber.value).toBe(5)
+
+      verseNumber.value = null
+      await nextTick()
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+  })
+
+  describe('handleScroll', () => {
+    it('clears focus when the user scrolls manually', () => {
+      const { focusedVerseNumber, focusVerseByNumber, handleScroll } = useSetup()
+
+      focusVerseByNumber(5, false)
+      handleScroll()
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+
+    it('keeps focus while programmatic scroll is in progress', () => {
+      const { focusedVerseNumber, focusVerseByNumber, handleScroll } = useSetup()
+
+      focusVerseByNumber(5, true)
+      handleScroll()
+
+      expect(focusedVerseNumber.value).toBe(5)
+    })
+
+    it('clears focus after programmatic scroll completes and user scrolls again', () => {
+      const { focusedVerseNumber, focusVerseByNumber, handleScroll } = useSetup()
+
+      focusVerseByNumber(5, true)
+      handleScroll()
+
+      expect(focusedVerseNumber.value).toBe(5)
+
+      vi.advanceTimersByTime(150)
+      handleScroll()
+
+      expect(focusedVerseNumber.value).toBeNull()
+    })
+  })
+
+  describe('overlayHeight', () => {
+    it('returns container scroll height while a verse is focused', () => {
+      const { overlayHeight, focusVerseByNumber } = useSetup({ scrollHeight: 640 })
+
+      focusVerseByNumber(5, false)
+
+      expect(overlayHeight.value).toBe(640)
+    })
+
+    it('returns zero when no verse is focused', () => {
+      const { overlayHeight } = useSetup({ scrollHeight: 640 })
+
+      expect(overlayHeight.value).toBe(0)
+    })
+  })
+})


### PR DESCRIPTION
- Added `focusVerseByNumber` method to `useVerseFocus` for programmatically focusing on specific verses.
- Integrated verse focusing in `VerseReference` component to handle popover visibility and verse focus.
- Updated `Verse` component to pass verse number to `BibleChapterVerseReference` for better context.
- Provided verse focus context in the chapter component to streamline verse interaction.