### PR TITLE
feat: implement shared modal component and refactor existing modals

### DIFF
--- a/app/components/bible/SearchModal.vue
+++ b/app/components/bible/SearchModal.vue
@@ -7,7 +7,7 @@ import { useNavigateToBible } from '~/composables/useNavigateToBible'
 const { goToChapter } = useNavigateToBible()
 const versionStore = useVersionStore()
 
-const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
+const modalRef = useModalRef('modalRef')
 const bookInputRef = useTemplateRef<HTMLInputElement>('bookInputRef')
 const chapterInputRef = useTemplateRef<HTMLInputElement>('chapterInputRef')
 const verseInputRef = useTemplateRef<HTMLInputElement>('verseInputRef')
@@ -74,7 +74,7 @@ watch(filteredBooks, (books) => {
   clearBookSelection()
   selectedChapter.value = null
 
-  dialogRef.value?.showModal()
+  modalRef.value?.open()
 
   // Focuses on the book field after opening
   nextTick(() => bookInputRef.value?.focus())
@@ -84,7 +84,7 @@ watch(filteredBooks, (books) => {
  * Closes the modal
  */
 const close = () => {
-  dialogRef.value?.close()
+  modalRef.value?.close()
 }
 
 /**
@@ -314,109 +314,93 @@ defineExpose({
 </script>
 
 <template>
-  <dialog
-    ref="dialogRef"
-    class="modal modal-bottom sm:modal-middle"
-    aria-labelledby="search-modal-title"
-    @click.self="close"
+  <SharedModal
+    ref="modalRef"
+    title="Pesquisar Referência Bíblica"
+    title-id="search-modal-title"
+    close-aria-label="Fechar modal de pesquisa"
   >
-    <div class="modal-box max-w-2xl sm:rounded-lg max-sm:max-w-full max-sm:h-[calc(100vh-4rem)] max-sm:mb-0 max-sm:mt-16 max-sm:rounded-b-none">
-      <!-- Header -->
-      <div class="flex items-center justify-between mb-4">
-        <h3 id="search-modal-title" class="font-bold text-lg">
-          Pesquisar Referência Bíblica
-        </h3>
-        <button
-          class="btn btn-sm btn-ghost btn-circle"
-          aria-label="Fechar modal de pesquisa"
-          @click="close"
-        >
-          <Icon icon="close" :size="20" />
-          <span class="sr-only">Fechar</span>
-        </button>
-      </div>
-
-      <!-- Search fields -->
-      <div class="space-y-4">
-        <!-- Book field -->
-        <div class="form-control">
-          <label class="label">
-            <span class="label-text font-semibold">Livro</span>
-          </label>
-          <div class="relative">
-            <input
-              ref="bookInputRef"
-              v-model="bookSearch"
-              type="text"
-              placeholder="Digite o nome do livro..."
-              class="input input-bordered w-full"
-              @input="handleBookInput"
-              @keydown.enter.prevent="handleBookKeydown"
-              @keydown.tab.prevent="handleBookKeydown"
-            />
-            <!-- Suggestions list -->
-            <div
-              v-if="bookSearch && filteredBooks.length > 0 && !selectedBook"
-              class="absolute z-10 w-full mt-1 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-60 overflow-y-auto"
+    <!-- Search fields -->
+    <div class="space-y-4">
+      <!-- Book field -->
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-semibold">Livro</span>
+        </label>
+        <div class="relative">
+          <input
+            ref="bookInputRef"
+            v-model="bookSearch"
+            type="text"
+            placeholder="Digite o nome do livro..."
+            class="input input-bordered w-full"
+            @input="handleBookInput"
+            @keydown.enter.prevent="handleBookKeydown"
+            @keydown.tab.prevent="handleBookKeydown"
+          />
+          <!-- Suggestions list -->
+          <div
+            v-if="bookSearch && filteredBooks.length > 0 && !selectedBook"
+            class="absolute z-10 w-full mt-1 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-60 overflow-y-auto"
+          >
+            <button
+              v-for="book in filteredBooks"
+              :key="book.abbreviation"
+              class="w-full text-left px-4 py-2 hover:bg-base-200 transition-colors"
+              @click="selectBook(book)"
             >
-              <button
-                v-for="book in filteredBooks"
-                :key="book.abbreviation"
-                class="w-full text-left px-4 py-2 hover:bg-base-200 transition-colors"
-                @click="selectBook(book)"
-              >
-                {{ book.name }}
-              </button>
-            </div>
+              {{ book.name }}
+            </button>
           </div>
         </div>
-
-        <!-- Chapter field -->
-        <div class="form-control">
-          <label class="label">
-            <span class="label-text font-semibold">Capítulo</span>
-            <span v-if="selectedBookData" class="label-text-alt text-base-content/60">
-              (máx: {{ selectedBookData.chapters.length }})
-            </span>
-          </label>
-          <input
-            ref="chapterInputRef"
-            type="number"
-            class="input input-bordered w-full"
-            :value="chapterSearch"
-            :min="1"
-            :max="selectedBookData?.chapters.length"
-            :placeholder="selectedBookData ? `Digite o capítulo (1-${selectedBookData.chapters.length})...` : 'Selecione um livro primeiro'"
-            :disabled="!selectedBook"
-            @input="handleChapterInput"
-            @keydown="handleChapterKeydown"
-          />
-        </div>
-
-        <!-- Verse field -->
-        <div class="form-control">
-          <label class="label">
-            <span class="label-text font-semibold">Versículo (opcional)</span>
-            <span v-if="selectedChapterVerses > 0" class="label-text-alt text-base-content/60">
-              (máx: {{ selectedChapterVerses }})
-            </span>
-          </label>
-          <input
-            ref="verseInputRef"
-            type="number"
-            class="input input-bordered w-full"
-            :value="verseSearch"
-            :min="1"
-            :max="selectedChapterVerses || 176"
-            :placeholder="selectedChapter ? `Digite o versículo (1-${selectedChapterVerses || 176})...` : 'Selecione um capítulo primeiro'"
-            :disabled="!selectedChapter"
-            @input="handleVerseInput"
-            @keydown="handleVerseKeydown"
-          />
-        </div>
       </div>
 
-      <!-- Actions -->
+      <!-- Chapter field -->
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-semibold">Capítulo</span>
+          <span v-if="selectedBookData" class="label-text-alt text-base-content/60">
+            (máx: {{ selectedBookData.chapters.length }})
+          </span>
+        </label>
+        <input
+          ref="chapterInputRef"
+          type="number"
+          class="input input-bordered w-full"
+          :value="chapterSearch"
+          :min="1"
+          :max="selectedBookData?.chapters.length"
+          :placeholder="selectedBookData ? `Digite o capítulo (1-${selectedBookData.chapters.length})...` : 'Selecione um livro primeiro'"
+          :disabled="!selectedBook"
+          @input="handleChapterInput"
+          @keydown="handleChapterKeydown"
+        />
+      </div>
+
+      <!-- Verse field -->
+      <div class="form-control">
+        <label class="label">
+          <span class="label-text font-semibold">Versículo (opcional)</span>
+          <span v-if="selectedChapterVerses > 0" class="label-text-alt text-base-content/60">
+            (máx: {{ selectedChapterVerses }})
+          </span>
+        </label>
+        <input
+          ref="verseInputRef"
+          type="number"
+          class="input input-bordered w-full"
+          :value="verseSearch"
+          :min="1"
+          :max="selectedChapterVerses || 176"
+          :placeholder="selectedChapter ? `Digite o versículo (1-${selectedChapterVerses || 176})...` : 'Selecione um capítulo primeiro'"
+          :disabled="!selectedChapter"
+          @input="handleVerseInput"
+          @keydown="handleVerseKeydown"
+        />
+      </div>
+    </div>
+
+    <template #footer>
       <div class="modal-action">
         <button
           class="btn btn-ghost"
@@ -432,6 +416,6 @@ defineExpose({
           Navegar
         </button>
       </div>
-    </div>
-  </dialog>
+    </template>
+  </SharedModal>
 </template>

--- a/app/components/bible/SelectedVersesActionModal.vue
+++ b/app/components/bible/SelectedVersesActionModal.vue
@@ -1,20 +1,16 @@
 <script setup lang="ts">
-const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
+const modalRef = useModalRef('modalRef')
 
 const emit = defineEmits<{
   close: []
 }>()
 
 const open = () => {
-  dialogRef.value?.showModal()
+  modalRef.value?.open()
 }
 
 const close = () => {
-  dialogRef.value?.close()
-}
-
-const handleClose = () => {
-  close()
+  modalRef.value?.close()
 }
 
 defineExpose({
@@ -24,15 +20,13 @@ defineExpose({
 </script>
 
 <template>
-  <dialog
-    ref="dialogRef"
+  <SharedModal
+    ref="modalRef"
     id="selected-verses-action-modal"
-    class="modal modal-bottom sm:modal-middle"
-    @click.self="handleClose"
+    :padded="false"
+    box-class="w-full max-h-[calc(100dvh-4rem)] flex flex-col"
     @close="emit('close')"
   >
-    <div class="modal-box max-w-2xl w-full max-h-[calc(100dvh-4rem)] flex flex-col p-0 sm:rounded-lg max-sm:max-w-full max-sm:mb-0 max-sm:mt-16 max-sm:rounded-b-none">
-      <slot />
-    </div>
-  </dialog>
+    <slot />
+  </SharedModal>
 </template>

--- a/app/components/bible/chapter/HistoryModal.vue
+++ b/app/components/bible/chapter/HistoryModal.vue
@@ -15,15 +15,11 @@ const {
   loadHistory
 } = useChapterHistory()
 
-const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
+const modalRef = useModalRef('modalRef')
 
 const open = () => {
   loadHistory()
-  dialogRef.value?.showModal()
-}
-
-const close = () => {
-  dialogRef.value?.close()
+  modalRef.value?.open()
 }
 
 const navigateToChapter = async (item: ChapterHistory) => {
@@ -39,7 +35,7 @@ const navigateToChapter = async (item: ChapterHistory) => {
   }
 
   goToChapter(item.book, item.chapter, item.verse)
-  close()
+  modalRef.value?.close()
 }
 
 // Formats the chapter display text (e.g., "Genesis 1:5" or "Genesis 1")
@@ -97,80 +93,64 @@ defineExpose({
 </script>
 
 <template>
-  <dialog
-    ref="dialogRef"
-    class="modal modal-bottom sm:modal-middle"
-    aria-labelledby="history-modal-title"
-    @click.self="close"
+  <SharedModal
+    ref="modalRef"
+    title="Histórico de Leitura"
+    title-id="history-modal-title"
+    close-aria-label="Fechar modal de histórico"
   >
-    <div class="modal-box max-w-2xl sm:rounded-lg max-sm:max-w-full max-sm:w-full max-sm:h-[calc(100dvh-4rem)] max-sm:mb-0 max-sm:mt-16 max-sm:rounded-b-none max-sm:flex max-sm:flex-col">
-      <!-- Header with close button -->
-      <div class="flex items-center justify-between mb-4 shrink-0">
-        <h3 id="history-modal-title" class="font-bold text-lg">
-          Histórico de Leitura
-        </h3>
-        <button 
-          class="btn btn-sm btn-ghost btn-circle"
-          aria-label="Fechar modal de histórico"
-          @click="close"
-        >
-          <Icon icon="close" :size="20" />
-          <span class="sr-only">Fechar</span>
-        </button>
-      </div>
-      
-      <!-- Empty state -->
-      <div v-if="chapterHistory.length === 0" class="text-center py-8 text-base-content/60">
-        <Icon icon="history" :size="48" class="mx-auto mb-2 opacity-50" />
-        <p>
-          Nenhuma leitura no histórico ainda.
-        </p>
-        <p class="text-sm mt-1">
-          Navegue pelos capítulos para adicionar ao histórico.
-        </p>
-      </div>
-      
-      <!-- History list -->
-      <div v-else class="space-y-4 overflow-y-auto flex-1 sm:max-h-96">
-        <section
-          v-for="group in groupedHistory"
-          :key="group.dayKey"
-        >
-          <h4 class="text-lg font-semibold text-base-content/70 mb-1">
-            {{ group.label }}
-          </h4>
-          <div class="space-y-2">
-            <button
-              v-for="item in group.items"
-              :key="historyItemKey(item)"
-              class="w-full text-left p-3 rounded-lg transition-colors flex items-center gap-3 border border-base-300 cursor-pointer hover:bg-base-200"
-              @click="navigateToChapter(item)"
-            >
-              <div class="flex-1">
-                <div class="font-semibold">
-                  {{ formatChapter(item) }}
-                </div>
-                <div class="text-xs text-base-content/60 mt-1 flex items-center gap-2">
-                  <span class="break-all">{{ versionStore.getVersionByAbbreviation(item.versionName)?.name ?? item.versionName }}</span>
-                  <span>•</span>
-                  <span>{{ formatTime(item.timestamp) }}</span>
-                </div>
+    <!-- Empty state -->
+    <div v-if="chapterHistory.length === 0" class="text-center py-8 text-base-content/60">
+      <Icon icon="history" :size="48" class="mx-auto mb-2 opacity-50" />
+      <p>
+        Nenhuma leitura no histórico ainda.
+      </p>
+      <p class="text-sm mt-1">
+        Navegue pelos capítulos para adicionar ao histórico.
+      </p>
+    </div>
+
+    <!-- History list -->
+    <div v-else class="space-y-4 overflow-y-auto flex-1 sm:max-h-96">
+      <section
+        v-for="group in groupedHistory"
+        :key="group.dayKey"
+      >
+        <h4 class="text-lg font-semibold text-base-content/70 mb-1">
+          {{ group.label }}
+        </h4>
+        <div class="space-y-2">
+          <button
+            v-for="item in group.items"
+            :key="historyItemKey(item)"
+            class="w-full text-left p-3 rounded-lg transition-colors flex items-center gap-3 border border-base-300 cursor-pointer hover:bg-base-200"
+            @click="navigateToChapter(item)"
+          >
+            <div class="flex-1">
+              <div class="font-semibold">
+                {{ formatChapter(item) }}
               </div>
-              <Icon icon="chevron_right" :size="20" class="text-base-content/40 self-center" />
-            </button>
-          </div>
-        </section>
-      </div>
-      
-      <!-- Clear action -->
-      <div v-if="chapterHistory.length > 0" class="mt-4 pt-4 border-t border-base-300 shrink-0">
-        <button 
+              <div class="text-xs text-base-content/60 mt-1 flex items-center gap-2">
+                <span class="break-all">{{ versionStore.getVersionByAbbreviation(item.versionName)?.name ?? item.versionName }}</span>
+                <span>•</span>
+                <span>{{ formatTime(item.timestamp) }}</span>
+              </div>
+            </div>
+            <Icon icon="chevron_right" :size="20" class="text-base-content/40 self-center" />
+          </button>
+        </div>
+      </section>
+    </div>
+
+    <template #footer>
+      <div v-if="chapterHistory.length > 0" class="mt-4 pt-4 border-t border-base-300">
+        <button
           class="btn btn-ghost btn-sm w-full"
           @click="clearHistory"
         >
           Limpar Histórico
         </button>
       </div>
-    </div>
-  </dialog>
+    </template>
+  </SharedModal>
 </template>

--- a/app/components/bible/chapter/VersionModal.vue
+++ b/app/components/bible/chapter/VersionModal.vue
@@ -9,30 +9,26 @@ const emit = defineEmits<{
 const versionStore = useVersionStore()
 
 const versionSearch = ref('')
-const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
+const modalRef = useModalRef('modalRef')
 
 const filteredVersions = computed(() => {
   if (!versionSearch.value) return versionStore.versions
 
   const searchValue = normalizeString(versionSearch.value)
 
-  return versionStore.versions.filter(v => 
-    normalizeString(v.abbreviation).includes(searchValue) || 
+  return versionStore.versions.filter(v =>
+    normalizeString(v.abbreviation).includes(searchValue) ||
     normalizeString(v.name).includes(searchValue)
   )
 })
 
 const open = () => {
-  dialogRef.value?.showModal()
-}
-
-const close = () => {
-  dialogRef.value?.close()
+  modalRef.value?.open()
 }
 
 const selectVersion = (version: Version) => {
   emit('select', version)
-  close()
+  modalRef.value?.close()
 }
 
 defineExpose({
@@ -41,60 +37,42 @@ defineExpose({
 </script>
 
 <template>
-  <dialog
-    ref="dialogRef"
-    class="modal modal-bottom sm:modal-middle"
-    aria-labelledby="version-modal-title"
-    @click.self="close"
+  <SharedModal
+    ref="modalRef"
+    title="Selecionar Versão"
+    title-id="version-modal-title"
+    close-aria-label="Fechar modal de seleção de versão"
   >
-    <div class="modal-box max-w-2xl sm:rounded-lg max-sm:max-w-full max-sm:w-full max-sm:h-[calc(100dvh-4rem)] max-sm:mb-0 max-sm:mt-16 max-sm:rounded-b-none max-sm:flex max-sm:flex-col">
-      <!-- Header with close button -->
-      <div class="flex items-center justify-between mb-4 shrink-0">
-        <h3 id="version-modal-title" class="font-bold text-lg">
-          Selecionar Versão
-        </h3>
-        <button 
-          class="btn btn-sm btn-ghost btn-circle"
-          aria-label="Fechar modal de seleção de versão"
-          @click="close"
-        >
-          <Icon icon="close" :size="20" />
-          <span class="sr-only">Fechar</span>
-        </button>
-      </div>
-      
-      <!-- Search input -->
-      <div class="mb-4 shrink-0">
-        <label class="input w-full">
-          <Icon icon="search" :size="25" />
-          <input
-            v-model="versionSearch"
-            type="search"
-            class="search-input text-base-content"
-            placeholder="Buscar versão..."
-          />
-        </label>
-      </div>
-      
-      <!-- List of Versions -->
-      <div class="space-y-2 overflow-y-auto flex-1 sm:max-h-96">
-        <button
-          v-for="version in filteredVersions"
-          :key="version.id"
-          class="w-full text-left p-3 rounded-lg transition-colors flex items-center gap-3 border border-base-300 cursor-pointer hover:bg-base-200"
-          :class="{
-            'bg-primary/10 border-primary': versionStore.currentVersion?.id === version.id
-          }"
-          @click="selectVersion(version)"
-        >
-          <div class="flex-1">
-            <div class="font-semibold">{{ version.abbreviation }}</div>
-            <div class="text-sm text-base-content/70">{{ version.name }}</div>
-          </div>
-          <Icon icon="chevron_right" :size="20" class="text-base-content/40 self-center" />
-        </button>
-      </div>
+    <!-- Search input -->
+    <div class="mb-4 shrink-0">
+      <label class="input w-full">
+        <Icon icon="search" :size="25" />
+        <input
+          v-model="versionSearch"
+          type="search"
+          class="search-input text-base-content"
+          placeholder="Buscar versão..."
+        />
+      </label>
     </div>
-  </dialog>
-</template>
 
+    <!-- List of Versions -->
+    <div class="space-y-2 overflow-y-auto flex-1 sm:max-h-96">
+      <button
+        v-for="version in filteredVersions"
+        :key="version.id"
+        class="w-full text-left p-3 rounded-lg transition-colors flex items-center gap-3 border border-base-300 cursor-pointer hover:bg-base-200"
+        :class="{
+          'bg-primary/10 border-primary': versionStore.currentVersion?.id === version.id
+        }"
+        @click="selectVersion(version)"
+      >
+        <div class="flex-1">
+          <div class="font-semibold">{{ version.abbreviation }}</div>
+          <div class="text-sm text-base-content/70">{{ version.name }}</div>
+        </div>
+        <Icon icon="chevron_right" :size="20" class="text-base-content/40 self-center" />
+      </button>
+    </div>
+  </SharedModal>
+</template>

--- a/app/components/help/support/SupportModal.vue
+++ b/app/components/help/support/SupportModal.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const dialogRef = useTemplateRef('dialogRef')
+const modalRef = useModalRef('modalRef')
 const formRef = useTemplateRef('formRef')
 const success = ref(false)
 const errorMessage = ref('')
@@ -8,11 +8,11 @@ const open = () => {
   success.value = false
   errorMessage.value = ''
   formRef.value?.reset()
-  dialogRef.value?.showModal()
+  modalRef.value?.open()
 }
 
 const close = () => {
-  dialogRef.value?.close()
+  modalRef.value?.close()
 }
 
 const onSupportSuccess = () => {
@@ -23,86 +23,68 @@ defineExpose({ open })
 </script>
 
 <template>
-  <dialog
-    ref="dialogRef"
-    class="modal modal-bottom sm:modal-middle"
-    aria-labelledby="support-modal-title"
+  <SharedModal
+    ref="modalRef"
+    title="Enviar Feedback"
+    title-id="support-modal-title"
+    header-bordered
+    box-class="flex flex-col sm:max-h-[min(85vh,720px)]"
   >
-    <div class="modal-box max-w-2xl flex flex-col sm:rounded-lg sm:max-h-[min(85vh,720px)] max-sm:max-w-full max-sm:w-full max-sm:h-[calc(100dvh-4rem)] max-sm:mb-0 max-sm:mt-16 max-sm:rounded-b-none">
-      <!-- Header (fixed) -->
-      <div class="flex items-center justify-between pb-4 border-b border-base-300 shrink-0">
-        <h3 id="support-modal-title" class="font-bold text-lg">
-          Enviar Feedback
-        </h3>
-        <button
-          class="btn btn-sm btn-ghost btn-circle"
-          aria-label="Fechar"
-          @click="close"
-        >
-          <Icon icon="close" :size="20" />
-        </button>
+    <!-- Success state -->
+    <div v-if="success" class="flex flex-col items-center gap-4 py-12 text-center flex-1">
+      <div class="rounded-full p-4 bg-success/10 flex items-center justify-center">
+        <Icon icon="check" :size="40" class="text-success" />
       </div>
-
-      <!-- Success state -->
-      <div v-if="success" class="flex flex-col items-center gap-4 py-12 text-center flex-1">
-        <div class="rounded-full p-4 bg-success/10 flex items-center justify-center">
-          <Icon icon="check" :size="40" class="text-success" />
-        </div>
-        <div>
-          <p class="text-lg font-semibold mb-1">Enviado com sucesso!</p>
-          <p class="text-sm text-base-content/70">
-            Obrigado pelo seu feedback. Vamos analisar sua solicitação o mais breve possível.
-          </p>
-        </div>
-        <button class="btn btn-primary btn-sm mt-2" @click="close">
-          Fechar
-        </button>
+      <div>
+        <p class="text-lg font-semibold mb-1">Enviado com sucesso!</p>
+        <p class="text-sm text-base-content/70">
+          Obrigado pelo seu feedback. Vamos analisar sua solicitação o mais breve possível.
+        </p>
       </div>
-
-      <template v-else>
-        <!-- Scrollable body -->
-        <div class="overflow-y-auto flex-1 py-4 -mx-1 px-1">
-          <!-- Description -->
-          <p class="text-sm text-base-content/70 mb-5">
-            Reporte bugs, envie sugestões de melhoria ou peça ajuda para alguma situação. Seu feedback nos ajuda a melhorar a sua experiência com a plataforma.
-          </p>
-
-          <HelpSupportForm
-            ref="formRef"
-            v-model:error="errorMessage"
-            @success="onSupportSuccess"
-          />
-        </div>
-
-        <!-- Footer (fixed) -->
-        <div class="pt-4 border-t border-base-300 shrink-0 space-y-3">
-          <div
-            v-if="errorMessage"
-            class="text-sm text-error flex items-start gap-2"
-            role="alert"
-          >
-            <Icon icon="info" :size="16" class="shrink-0 mt-0.5" />
-            <span>{{ errorMessage }}</span>
-          </div>
-          <div class="flex justify-end gap-3">
-            <button type="button" class="btn btn-ghost min-w-28" @click="close">
-              Cancelar
-            </button>
-            <button
-              type="button"
-              class="btn btn-primary min-w-28"
-              @click="formRef?.requestSubmit()"
-            >
-              <span v-if="formRef?.loading" class="loading loading-spinner loading-md" />
-              {{ formRef?.loading ? 'Enviando...' : 'Enviar' }}
-            </button>
-          </div>
-        </div>
-      </template>
+      <button class="btn btn-primary btn-sm mt-2" @click="close">
+        Fechar
+      </button>
     </div>
 
-    <form method="dialog" class="modal-backdrop">
-      <button>close</button>
-    </form>
-  </dialog>
+    <template v-else>
+      <!-- Scrollable body -->
+      <div class="overflow-y-auto flex-1 py-4 -mx-1 px-1">
+        <!-- Description -->
+        <p class="text-sm text-base-content/70 mb-5">
+          Reporte bugs, envie sugestões de melhoria ou peça ajuda para alguma situação. Seu feedback nos ajuda a melhorar a sua experiência com a plataforma.
+        </p>
+
+        <HelpSupportForm
+          ref="formRef"
+          v-model:error="errorMessage"
+          @success="onSupportSuccess"
+        />
+      </div>
+
+      <!-- Footer (fixed) -->
+      <div class="pt-4 border-t border-base-300 shrink-0 space-y-3">
+        <div
+          v-if="errorMessage"
+          class="text-sm text-error flex items-start gap-2"
+          role="alert"
+        >
+          <Icon icon="info" :size="16" class="shrink-0 mt-0.5" />
+          <span>{{ errorMessage }}</span>
+        </div>
+        <div class="flex justify-end gap-3">
+          <button type="button" class="btn btn-ghost min-w-28" @click="close">
+            Cancelar
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary min-w-28"
+            @click="formRef?.requestSubmit()"
+          >
+            <span v-if="formRef?.loading" class="loading loading-spinner loading-md" />
+            {{ formRef?.loading ? 'Enviando...' : 'Enviar' }}
+          </button>
+        </div>
+      </div>
+    </template>
+  </SharedModal>
 </template>

--- a/app/components/shared/Modal.vue
+++ b/app/components/shared/Modal.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  title?: string
+  titleId?: string
+  closeAriaLabel?: string
+  padded?: boolean
+  closeOnBackdrop?: boolean
+  headerBordered?: boolean
+}>(), {
+  padded: true,
+  closeOnBackdrop: true,
+  closeAriaLabel: 'Fechar',
+  headerBordered: false,
+})
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const slots = useSlots()
+const dialogRef = useTemplateRef<HTMLDialogElement>('dialogRef')
+const generatedTitleId = useId()
+const resolvedTitleId = computed(() => props.titleId ?? generatedTitleId)
+
+const boxClasses = computed(() => [
+  'modal-box max-w-2xl sm:rounded-lg max-sm:max-w-full max-sm:w-full max-sm:h-[calc(100dvh-4rem)] max-sm:mb-0 max-sm:mt-16 max-sm:rounded-b-none max-sm:flex max-sm:flex-col',
+  {
+    'p-0': !props.padded,
+  },
+])
+
+const showHeader = computed(() => Boolean(props.title || slots.header))
+
+const open = () => {
+  dialogRef.value?.showModal()
+}
+
+const close = () => {
+  dialogRef.value?.close()
+}
+
+const handleBackdropClick = () => {
+  if (!props.closeOnBackdrop) return
+
+  close()
+}
+
+const handleDialogClose = () => {
+  emit('close')
+}
+
+defineExpose({
+  open,
+  close,
+} satisfies SharedModalExposed)
+</script>
+
+<template>
+  <dialog
+    ref="dialogRef"
+    class="modal modal-bottom sm:modal-middle"
+    :aria-labelledby="showHeader ? resolvedTitleId : undefined"
+    @click.self="handleBackdropClick"
+    @close="handleDialogClose"
+  >
+    <div :class="boxClasses">
+      <slot v-if="$slots.header" name="header" />
+
+      <div
+        v-else-if="title"
+        class="flex items-center justify-between shrink-0"
+        :class="headerBordered ? 'pb-4 border-b border-base-300' : 'mb-4'"
+      >
+        <h3 :id="resolvedTitleId" class="font-bold text-lg">
+          {{ title }}
+        </h3>
+        <button
+          type="button"
+          class="btn btn-sm btn-ghost btn-circle"
+          :aria-label="closeAriaLabel"
+          @click="close"
+        >
+          <Icon icon="close" :size="20" />
+          <span class="sr-only">Fechar</span>
+        </button>
+      </div>
+
+      <slot />
+
+      <footer v-if="$slots.footer" class="shrink-0">
+        <slot name="footer" />
+      </footer>
+    </div>
+  </dialog>
+</template>

--- a/app/components/shared/Modal.vue
+++ b/app/components/shared/Modal.vue
@@ -4,11 +4,10 @@ const props = withDefaults(defineProps<{
   titleId?: string
   closeAriaLabel?: string
   padded?: boolean
-  closeOnBackdrop?: boolean
   headerBordered?: boolean
+  boxClass?: string
 }>(), {
   padded: true,
-  closeOnBackdrop: true,
   closeAriaLabel: 'Fechar',
   headerBordered: false,
 })
@@ -27,6 +26,7 @@ const boxClasses = computed(() => [
   {
     'p-0': !props.padded,
   },
+  props.boxClass,
 ])
 
 const showHeader = computed(() => Boolean(props.title || slots.header))
@@ -37,12 +37,6 @@ const open = () => {
 
 const close = () => {
   dialogRef.value?.close()
-}
-
-const handleBackdropClick = () => {
-  if (!props.closeOnBackdrop) return
-
-  close()
 }
 
 const handleDialogClose = () => {
@@ -60,7 +54,6 @@ defineExpose({
     ref="dialogRef"
     class="modal modal-bottom sm:modal-middle"
     :aria-labelledby="showHeader ? resolvedTitleId : undefined"
-    @click.self="handleBackdropClick"
     @close="handleDialogClose"
   >
     <div :class="boxClasses">
@@ -91,5 +84,9 @@ defineExpose({
         <slot name="footer" />
       </footer>
     </div>
+
+    <form method="dialog" class="modal-backdrop">
+      <button aria-label="Fechar">close</button>
+    </form>
   </dialog>
 </template>

--- a/app/composables/useModalRef.ts
+++ b/app/composables/useModalRef.ts
@@ -1,0 +1,10 @@
+import { useTemplateRef } from 'vue'
+
+export type SharedModalExposed = {
+  open: () => void
+  close: () => void
+}
+
+export const useModalRef = <T extends SharedModalExposed = SharedModalExposed>(
+  name: string,
+) => useTemplateRef<T>(name)

--- a/app/composables/useSupportModal.ts
+++ b/app/composables/useSupportModal.ts
@@ -4,9 +4,7 @@ type SupportModalController = {
 
 type MaybeRef<T> = { value: T } | null | undefined
 
-type SupportModalExposed = {
-  open: () => void
-}
+type SupportModalExposed = Pick<SharedModalExposed, 'open'>
 
 export const useSupportModal = () => {
   const controller = useState<SupportModalController | null>(

--- a/test/nuxt/components/shared/Modal.test.ts
+++ b/test/nuxt/components/shared/Modal.test.ts
@@ -1,0 +1,260 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DOMWrapper, VueWrapper } from '@vue/test-utils'
+import { mockComponent, mountSuspended } from '@nuxt/test-utils/runtime'
+import SharedModal from '~/components/shared/Modal.vue'
+
+mockComponent('Icon', {
+  props: ['icon'],
+  template: '<span />',
+})
+
+type ModalWrapper = VueWrapper<InstanceType<typeof SharedModal>>
+
+function setupDialogSpies() {
+  return {
+    showModal: vi.spyOn(HTMLDialogElement.prototype, 'showModal').mockImplementation(() => {}),
+    close: vi.spyOn(HTMLDialogElement.prototype, 'close').mockImplementation(() => {}),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function mountModal(
+  props: Record<string, unknown> = {},
+  slots: Record<string, string> = {},
+) {
+  const wrapper = await mountSuspended(SharedModal, {
+    props: {
+      title: 'Modal',
+      ...props,
+    },
+    slots: {
+      default: '<p class="default-slot">Conteúdo</p>',
+      ...slots,
+    },
+  })
+
+  const dialog = wrapper.find('dialog')
+
+  return { wrapper: wrapper as ModalWrapper, dialog }
+}
+
+function headerContainer(dialog: DOMWrapper<HTMLDialogElement>) {
+  return dialog.find('h3').element.parentElement!
+}
+
+describe('SharedModal', () => {
+  describe('dialog API', () => {
+    it('opens the native dialog via exposed open()', async () => {
+      const { showModal } = setupDialogSpies()
+      const { wrapper } = await mountModal()
+
+      wrapper.vm.open()
+
+      expect(showModal).toHaveBeenCalledOnce()
+    })
+
+    it('closes the native dialog via exposed close()', async () => {
+      const { close } = setupDialogSpies()
+      const { wrapper } = await mountModal()
+
+      wrapper.vm.close()
+
+      expect(close).toHaveBeenCalledOnce()
+    })
+
+    it('emits close when the dialog fires a native close event', async () => {
+      const { wrapper, dialog } = await mountModal()
+
+      await dialog.trigger('close')
+
+      expect(wrapper.emitted('close')).toHaveLength(1)
+    })
+  })
+
+  describe('backdrop behavior', () => {
+    it('closes on backdrop click when closeOnBackdrop is enabled', async () => {
+      const { close } = setupDialogSpies()
+      const { dialog } = await mountModal({ closeOnBackdrop: true })
+
+      await dialog.trigger('click')
+
+      expect(close).toHaveBeenCalledOnce()
+    })
+
+    it('does not close on backdrop click when closeOnBackdrop is disabled', async () => {
+      const { close } = setupDialogSpies()
+      const { dialog } = await mountModal({ closeOnBackdrop: false })
+
+      await dialog.trigger('click')
+
+      expect(close).not.toHaveBeenCalled()
+    })
+
+    it('does not close when clicking modal content', async () => {
+      const { close } = setupDialogSpies()
+      const { dialog } = await mountModal()
+
+      await dialog.find('.modal-box').trigger('click')
+      await dialog.find('.default-slot').trigger('click')
+
+      expect(close).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('header', () => {
+    it('renders title and titleId', async () => {
+      const { dialog } = await mountModal({
+        title: 'Meu título',
+        titleId: 'custom-id',
+      })
+
+      expect(dialog.find('#custom-id').text()).toBe('Meu título')
+      expect(dialog.attributes('aria-labelledby')).toBe('custom-id')
+    })
+
+    it('generates titleId when titleId prop is omitted', async () => {
+      const { dialog } = await mountModal({ title: 'Título gerado' })
+
+      const titleId = dialog.find('h3').attributes('id')
+
+      expect(titleId).toBeTruthy()
+      expect(dialog.attributes('aria-labelledby')).toBe(titleId)
+    })
+
+    it('omits aria-labelledby when there is no header', async () => {
+      const { dialog } = await mountModal({ title: undefined })
+
+      expect(dialog.attributes('aria-labelledby')).toBeUndefined()
+      expect(dialog.find('h3').exists()).toBe(false)
+    })
+
+    it('sets aria-labelledby when using a custom header slot', async () => {
+      const { dialog } = await mountModal(
+        { title: undefined, titleId: 'header-slot-id' },
+        { header: '<div class="custom-header">Header customizado</div>' },
+      )
+
+      expect(dialog.attributes('aria-labelledby')).toBe('header-slot-id')
+      expect(dialog.find('.custom-header').exists()).toBe(true)
+      expect(dialog.find('h3').exists()).toBe(false)
+    })
+
+    it('renders a custom header slot instead of the title prop', async () => {
+      const { dialog } = await mountModal(
+        { title: 'Ignorado' },
+        { header: '<div class="custom-header">Header customizado</div>' },
+      )
+
+      expect(dialog.find('.custom-header').exists()).toBe(true)
+      expect(dialog.find('h3').exists()).toBe(false)
+    })
+
+    it('applies bordered header classes when headerBordered is true', async () => {
+      const { dialog } = await mountModal({ headerBordered: true })
+
+      const header = headerContainer(dialog)
+
+      expect(header.className).toContain('pb-4')
+      expect(header.className).toContain('border-b')
+      expect(header.className).toContain('border-base-300')
+      expect(header.className).not.toContain('mb-4')
+    })
+
+    it('applies default header spacing when headerBordered is false', async () => {
+      const { dialog } = await mountModal({ headerBordered: false })
+
+      const header = headerContainer(dialog)
+
+      expect(header.className).toContain('mb-4')
+      expect(header.className).not.toContain('border-b')
+    })
+
+    it('uses the default close aria label', async () => {
+      const { dialog } = await mountModal()
+
+      expect(dialog.find('button[aria-label="Fechar"]').exists()).toBe(true)
+    })
+
+    it('uses a custom close aria label', async () => {
+      const { dialog } = await mountModal({ closeAriaLabel: 'Fechar modal' })
+
+      expect(dialog.find('button[aria-label="Fechar modal"]').exists()).toBe(true)
+    })
+
+    it('renders a screen reader only close label', async () => {
+      const { dialog } = await mountModal()
+
+      expect(dialog.find('.sr-only').text()).toBe('Fechar')
+    })
+
+    it('closes when the header close button is clicked', async () => {
+      const { close } = setupDialogSpies()
+      const { dialog } = await mountModal({ closeAriaLabel: 'Fechar modal' })
+
+      await dialog.get('button[aria-label="Fechar modal"]').trigger('click')
+
+      expect(close).toHaveBeenCalledOnce()
+    })
+  })
+
+  describe('layout', () => {
+    it('renders dialog with DaisyUI modal classes', async () => {
+      const { dialog } = await mountModal()
+
+      expect(dialog.classes()).toContain('modal')
+      expect(dialog.classes()).toContain('modal-bottom')
+      expect(dialog.classes()).toContain('sm:modal-middle')
+    })
+
+    it('renders modal-box with shared layout classes', async () => {
+      const { dialog } = await mountModal()
+      const box = dialog.find('.modal-box')
+
+      expect(box.classes()).toContain('max-w-2xl')
+      expect(box.classes()).toContain('sm:rounded-lg')
+      expect(box.classes()).toContain('max-sm:flex')
+      expect(box.classes()).toContain('max-sm:flex-col')
+    })
+
+    it('applies p-0 to modal-box when padded is false', async () => {
+      const { dialog } = await mountModal({ padded: false })
+
+      expect(dialog.find('.modal-box').classes()).toContain('p-0')
+    })
+
+    it('keeps default padding when padded is true', async () => {
+      const { dialog } = await mountModal({ padded: true })
+
+      expect(dialog.find('.modal-box').classes()).not.toContain('p-0')
+    })
+  })
+
+  describe('slots', () => {
+    it('renders default slot content', async () => {
+      const { dialog } = await mountModal({}, {
+        default: '<p class="body-content">Corpo customizado</p>',
+      })
+
+      expect(dialog.find('.body-content').text()).toBe('Corpo customizado')
+    })
+
+    it('renders the footer slot', async () => {
+      const { dialog } = await mountModal(
+        {},
+        { footer: '<div class="custom-footer">Rodapé</div>' },
+      )
+
+      expect(dialog.find('footer').exists()).toBe(true)
+      expect(dialog.find('.custom-footer').text()).toBe('Rodapé')
+    })
+
+    it('does not render footer element without footer slot', async () => {
+      const { dialog } = await mountModal()
+
+      expect(dialog.find('footer').exists()).toBe(false)
+    })
+  })
+})

--- a/test/nuxt/components/shared/Modal.test.ts
+++ b/test/nuxt/components/shared/Modal.test.ts
@@ -75,22 +75,13 @@ describe('SharedModal', () => {
   })
 
   describe('backdrop behavior', () => {
-    it('closes on backdrop click when closeOnBackdrop is enabled', async () => {
-      const { close } = setupDialogSpies()
-      const { dialog } = await mountModal({ closeOnBackdrop: true })
+    it('uses a native dialog form for backdrop dismissal', async () => {
+      const { dialog } = await mountModal()
+      const form = dialog.find('form.modal-backdrop')
 
-      await dialog.trigger('click')
-
-      expect(close).toHaveBeenCalledOnce()
-    })
-
-    it('does not close on backdrop click when closeOnBackdrop is disabled', async () => {
-      const { close } = setupDialogSpies()
-      const { dialog } = await mountModal({ closeOnBackdrop: false })
-
-      await dialog.trigger('click')
-
-      expect(close).not.toHaveBeenCalled()
+      expect(form.exists()).toBe(true)
+      expect(form.attributes('method')).toBe('dialog')
+      expect(form.find('button[aria-label="Fechar"]').exists()).toBe(true)
     })
 
     it('does not close when clicking modal content', async () => {
@@ -229,6 +220,18 @@ describe('SharedModal', () => {
       const { dialog } = await mountModal({ padded: true })
 
       expect(dialog.find('.modal-box').classes()).not.toContain('p-0')
+    })
+
+    it('applies custom box classes', async () => {
+      const { dialog } = await mountModal({ boxClass: 'custom-box-class' })
+
+      expect(dialog.find('.modal-box').classes()).toContain('custom-box-class')
+    })
+
+    it('forwards id attribute to the dialog element', async () => {
+      const { dialog } = await mountModal({ id: 'custom-modal-id' })
+
+      expect(dialog.attributes('id')).toBe('custom-modal-id')
     })
   })
 


### PR DESCRIPTION
- Created a new `SharedModal` component to standardize modal behavior and styling across the application.
- Refactored `HistoryModal` and `VersionModal` to utilize the new `SharedModal` component, improving code reusability and maintainability.
- Introduced a `useModalRef` composable for managing modal references, enhancing the modal opening and closing logic.
- Added unit tests for the `SharedModal` to ensure proper functionality and interaction.